### PR TITLE
fix: ensure ionesco launcher keeps cwd

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -250,7 +250,7 @@ To hit a breakpoint inside the sandbox container run:
 DEBUG=1 gemini
 ```
 
-**Note:** If you have `DEBUG=true` in a project's `.env` file, it won't affect gemini-cli due to automatic exclusion. Use `.gemini/.env` files for gemini-cli specific debug settings.
+**Note:** If you have `DEBUG=true` in a project's `.env` file, it won't affect gemini-cli due to automatic exclusion. Use `.ionesco/.env` files for gemini-cli specific debug settings.
 
 ### React DevTools
 
@@ -284,13 +284,13 @@ To debug the CLI's React-based UI, you can use React DevTools. Ink, the library 
 
 ### macOS Seatbelt
 
-On macOS, `gemini` uses Seatbelt (`sandbox-exec`) under a `permissive-open` profile (see `packages/cli/src/utils/sandbox-macos-permissive-open.sb`) that restricts writes to the project folder but otherwise allows all other operations and outbound network traffic ("open") by default. You can switch to a `restrictive-closed` profile (see `packages/cli/src/utils/sandbox-macos-restrictive-closed.sb`) that declines all operations and outbound network traffic ("closed") by default by setting `SEATBELT_PROFILE=restrictive-closed` in your environment or `.env` file. Available built-in profiles are `{permissive,restrictive}-{open,closed,proxied}` (see below for proxied networking). You can also switch to a custom profile `SEATBELT_PROFILE=<profile>` if you also create a file `.gemini/sandbox-macos-<profile>.sb` under your project settings directory `.gemini`.
+On macOS, `gemini` uses Seatbelt (`sandbox-exec`) under a `permissive-open` profile (see `packages/cli/src/utils/sandbox-macos-permissive-open.sb`) that restricts writes to the project folder but otherwise allows all other operations and outbound network traffic ("open") by default. You can switch to a `restrictive-closed` profile (see `packages/cli/src/utils/sandbox-macos-restrictive-closed.sb`) that declines all operations and outbound network traffic ("closed") by default by setting `SEATBELT_PROFILE=restrictive-closed` in your environment or `.env` file. Available built-in profiles are `{permissive,restrictive}-{open,closed,proxied}` (see below for proxied networking). You can also switch to a custom profile `SEATBELT_PROFILE=<profile>` if you also create a file `.ionesco/sandbox-macos-<profile>.sb` under your project settings directory `.ionesco`.
 
 ### Container-based Sandboxing (All Platforms)
 
 For stronger container-based sandboxing on macOS or other platforms, you can set `GEMINI_SANDBOX=true|docker|podman|<command>` in your environment or `.env` file. The specified command (or if `true` then either `docker` or `podman`) must be installed on the host machine. Once enabled, `npm run build:all` will build a minimal container ("sandbox") image and `npm start` will launch inside a fresh instance of that container. The first build can take 20-30s (mostly due to downloading of the base image) but after that both build and start overhead should be minimal. Default builds (`npm run build`) will not rebuild the sandbox.
 
-Container-based sandboxing mounts the project directory (and system temp directory) with read-write access and is started/stopped/removed automatically as you start/stop Ionesco CLI. Files created within the sandbox should be automatically mapped to your user/group on host machine. You can easily specify additional mounts, ports, or environment variables by setting `SANDBOX_{MOUNTS,PORTS,ENV}` as needed. You can also fully customize the sandbox for your projects by creating the files `.gemini/sandbox.Dockerfile` and/or `.gemini/sandbox.bashrc` under your project settings directory (`.gemini`) and running `gemini` with `BUILD_SANDBOX=1` to trigger building of your custom sandbox.
+Container-based sandboxing mounts the project directory (and system temp directory) with read-write access and is started/stopped/removed automatically as you start/stop Ionesco CLI. Files created within the sandbox should be automatically mapped to your user/group on host machine. You can easily specify additional mounts, ports, or environment variables by setting `SANDBOX_{MOUNTS,PORTS,ENV}` as needed. You can also fully customize the sandbox for your projects by creating the files `.ionesco/sandbox.Dockerfile` and/or `.ionesco/sandbox.bashrc` under your project settings directory (`.ionesco`) and running `gemini` with `BUILD_SANDBOX=1` to trigger building of your custom sandbox.
 
 #### Proxied Networking
 

--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ The default configuration continues to use Google's Gemini models. Configure API
 
 Ionesco CLI ships with an experimental Grok provider backed by the Python sidecar under `providers/grok_sidecar/`.
 
-1. Run `./scripts/setup.sh` (or `scripts\setup.bat` on Windows) to create the sidecar virtualenv and install dependencies.
+1. Run `./setup.sh` (or `scripts\setup.bat` on Windows) to create the sidecar virtualenv and install dependencies.
 2. Copy `providers/grok_sidecar/.env.example` to `.env` and add:
    ```bash
    GROK_API_KEY=your_api_key
    GROK_MODEL=your_preferred_model_id   # optional; defaults to grok-4-fast-reasoning-latest
    ```
-3. Launch the CLI (`./scripts/start.sh` or `scripts\start.bat`).
+3. Launch the CLI (`./start.sh` or `scripts\start.bat`).
 4. Switch providers inside the session:
    ```
    /agent list          # show available providers
@@ -91,7 +91,7 @@ Choose the authentication method that best fits your needs:
 #### Start Ionesco CLI, then choose _Login with Google_ and follow the browser authentication flow when prompted
 
 ```bash
-./scripts/start.sh
+./start.sh
 ```
 
 #### If you are using a paid Code Assist License from your organization, remember to set the Google Cloud Project
@@ -99,7 +99,7 @@ Choose the authentication method that best fits your needs:
 ```bash
 # Set your Google Cloud Project
 export GOOGLE_CLOUD_PROJECT="YOUR_PROJECT_NAME"
-./scripts/start.sh
+./start.sh
 ```
 
 ### Option 2: Gemini API Key
@@ -115,7 +115,7 @@ export GOOGLE_CLOUD_PROJECT="YOUR_PROJECT_NAME"
 ```bash
 # Get your key from https://aistudio.google.com/apikey
 export GEMINI_API_KEY="YOUR_API_KEY"
-./scripts/start.sh
+./start.sh
 ```
 
 ### Option 3: Vertex AI
@@ -132,7 +132,7 @@ export GEMINI_API_KEY="YOUR_API_KEY"
 # Get your key from Google Cloud Console
 export GOOGLE_API_KEY="YOUR_API_KEY"
 export GOOGLE_GENAI_USE_VERTEXAI=true
-./scripts/start.sh
+./start.sh
 ```
 
 For Google Workspace accounts and other authentication methods, see the [authentication guide](./docs/cli/authentication.md).
@@ -148,10 +148,10 @@ cd ionesco-cli
 
 # Install Node dependencies and prime the Grok sidecar
 npm install
-./scripts/setup.sh
+./setup.sh
 
 # Launch the CLI (use scripts\start.bat on Windows)
-./scripts/start.sh
+./start.sh
 ```
 
 > Tip: run `./scripts/create_alias.sh` to expose a `gemini` shell alias for
@@ -162,7 +162,7 @@ npm install
 #### Start in current directory
 
 ```bash
-./scripts/start.sh
+./start.sh
 ```
 
 #### Include multiple directories
@@ -202,7 +202,7 @@ Inside the running session, `/agent list` shows available providers and `/agent 
 
 ```bash
 cd new-project/
-./scripts/start.sh
+./start.sh
 > Write me a Discord bot that answers questions using a FAQ.md file I will provide
 ```
 
@@ -211,7 +211,7 @@ cd new-project/
 ```bash
 git clone https://github.com/your-org/ionesco-cli.git
 cd ionesco-cli
-./scripts/start.sh
+./start.sh
 > Give me a summary of all of the changes that went in yesterday
 ```
 
@@ -254,7 +254,7 @@ cd ionesco-cli
 
 - [**Settings Reference**](./docs/cli/configuration.md) - All configuration options
 - [**Theme Customization**](./docs/cli/themes.md) - Visual customization
-- [**.gemini Directory**](./docs/gemini-ignore.md) - Project-specific settings
+- [**.ionesco Directory**](./docs/gemini-ignore.md) - Project-specific settings
 - [**Environment Variables**](./docs/cli/configuration.md#environment-variables)
 
 ### Troubleshooting & Support
@@ -265,7 +265,7 @@ cd ionesco-cli
 
 ### Using MCP Servers
 
-Configure MCP servers in `~/.gemini/settings.json` to extend Ionesco CLI with custom tools:
+Configure MCP servers in `~/.ionesco/settings.json` to extend Ionesco CLI with custom tools:
 
 ```text
 > @github List my open pull requests

--- a/docs/checkpointing.md
+++ b/docs/checkpointing.md
@@ -6,7 +6,7 @@ The Ionesco CLI includes a Checkpointing feature that automatically saves a snap
 
 When you approve a tool that modifies the file system (like `write_file` or `replace`), the CLI automatically creates a "checkpoint." This checkpoint includes:
 
-1.  **A Git Snapshot:** A commit is made in a special, shadow Git repository located in your home directory (`~/.gemini/history/<project_hash>`). This snapshot captures the complete state of your project files at that moment. It does **not** interfere with your own project's Git repository.
+1.  **A Git Snapshot:** A commit is made in a special, shadow Git repository located in your home directory (`~/.ionesco/history/<project_hash>`). This snapshot captures the complete state of your project files at that moment. It does **not** interfere with your own project's Git repository.
 2.  **Conversation History:** The entire conversation you've had with the agent up to that point is saved.
 3.  **The Tool Call:** The specific tool call that was about to be executed is also stored.
 
@@ -16,7 +16,7 @@ If you want to undo the change or simply go back, you can use the `/restore` com
 - Restore the conversation history in the CLI.
 - Re-propose the original tool call, allowing you to run it again, modify it, or simply ignore it.
 
-All checkpoint data, including the Git snapshot and conversation history, is stored locally on your machine. The Git snapshot is stored in the shadow repository while the conversation history and tool calls are saved in a JSON file in your project's temporary directory, typically located at `~/.gemini/tmp/<project_hash>/checkpoints`.
+All checkpoint data, including the Git snapshot and conversation history, is stored locally on your machine. The Git snapshot is stored in the shadow repository while the conversation history and tool calls are saved in a JSON file in your project's temporary directory, typically located at `~/.ionesco/tmp/<project_hash>/checkpoints`.
 
 ## Enabling the Feature
 

--- a/docs/cli/authentication.md
+++ b/docs/cli/authentication.md
@@ -119,17 +119,17 @@ The Ionesco CLI requires you to authenticate with Google's AI services. On initi
 
 ### Persisting Environment Variables with `.env` Files
 
-You can create a **`.gemini/.env`** file in your project directory or in your home directory. Creating a plain **`.env`** file also works, but `.gemini/.env` is recommended to keep Gemini variables isolated from other tools.
+You can create a **`.ionesco/.env`** file in your project directory or in your home directory. Creating a plain **`.env`** file also works, but `.ionesco/.env` is recommended to keep Gemini variables isolated from other tools.
 
-**Important:** Some environment variables (like `DEBUG` and `DEBUG_MODE`) are automatically excluded from project `.env` files to prevent interference with gemini-cli behavior. Use `.gemini/.env` files for gemini-cli specific variables.
+**Important:** Some environment variables (like `DEBUG` and `DEBUG_MODE`) are automatically excluded from project `.env` files to prevent interference with gemini-cli behavior. Use `.ionesco/.env` files for gemini-cli specific variables.
 
 Ionesco CLI automatically loads environment variables from the **first** `.env` file it finds, using the following search order:
 
 1. Starting in the **current directory** and moving upward toward `/`, for each directory it checks:
-   1. `.gemini/.env`
+   1. `.ionesco/.env`
    2. `.env`
 2. If no file is found, it falls back to your **home directory**:
-   - `~/.gemini/.env`
+   - `~/.ionesco/.env`
    - `~/.env`
 
 > **Important:** The search stops at the **first** file encountered—variables are **not merged** across multiple files.
@@ -139,15 +139,15 @@ Ionesco CLI automatically loads environment variables from the **first** `.env` 
 **Project-specific overrides** (take precedence when you are inside the project):
 
 ```bash
-mkdir -p .gemini
-echo 'GOOGLE_CLOUD_PROJECT="your-project-id"' >> .gemini/.env
+mkdir -p .ionesco
+echo 'GOOGLE_CLOUD_PROJECT="your-project-id"' >> .ionesco/.env
 ```
 
 **User-wide settings** (available in every directory):
 
 ```bash
-mkdir -p ~/.gemini
-cat >> ~/.gemini/.env <<'EOF'
+mkdir -p ~/.ionesco
+cat >> ~/.ionesco/.env <<'EOF'
 GOOGLE_CLOUD_PROJECT="your-project-id"
 GEMINI_API_KEY="your-gemini-api-key"
 EOF

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -9,7 +9,7 @@ Slash commands provide meta-level control over the CLI itself.
 ### Built-in Commands
 
 - **`/bug`**
-  - **Description:** File an issue about Ionesco CLI. By default, the issue is filed within the GitHub repository for Ionesco CLI. The string you enter after `/bug` will become the headline for the bug being filed. The default `/bug` behavior can be modified using the `advanced.bugCommand` setting in your `.gemini/settings.json` files.
+  - **Description:** File an issue about Ionesco CLI. By default, the issue is filed within the GitHub repository for Ionesco CLI. The string you enter after `/bug` will become the headline for the bug being filed. The default `/bug` behavior can be modified using the `advanced.bugCommand` setting in your `.ionesco/settings.json` files.
 
 - **`/chat`**
   - **Description:** Save and resume conversation history for branching conversation state interactively, or resuming a previous state from a later session.
@@ -18,8 +18,8 @@ Slash commands provide meta-level control over the CLI itself.
       - **Description:** Saves the current conversation history. You must add a `<tag>` for identifying the conversation state.
       - **Usage:** `/chat save <tag>`
       - **Details on Checkpoint Location:** The default locations for saved chat checkpoints are:
-        - Linux/macOS: `~/.gemini/tmp/<project_hash>/`
-        - Windows: `C:\Users\<YourUsername>\.gemini\tmp\<project_hash>\`
+        - Linux/macOS: `~/.ionesco/tmp/<project_hash>/`
+        - Windows: `C:\Users\<YourUsername>\.ionesco\tmp\<project_hash>\`
         - When you run `/chat list`, the CLI only scans these specific directories to find available checkpoints.
         - **Note:** These checkpoints are for manually saving and resuming conversation states. For automatic checkpoints created before file modifications, see the [Checkpointing documentation](../checkpointing.md).
     - **`resume`**
@@ -103,7 +103,7 @@ Slash commands provide meta-level control over the CLI itself.
 
 - **`/settings`**
   - **Description:** Open the settings editor to view and modify Ionesco CLI settings.
-  - **Details:** This command provides a user-friendly interface for changing settings that control the behavior and appearance of Ionesco CLI. It is equivalent to manually editing the `.gemini/settings.json` file, but with validation and guidance to prevent errors.
+  - **Details:** This command provides a user-friendly interface for changing settings that control the behavior and appearance of Ionesco CLI. It is equivalent to manually editing the `.ionesco/settings.json` file, but with validation and guidance to prevent errors.
   - **Usage:** Simply run `/settings` and the editor will open. You can then browse or search for specific settings, view their current values, and modify them as desired. Changes to some settings are applied immediately, while others require a restart.
 
 - **`/stats`**
@@ -141,7 +141,7 @@ Slash commands provide meta-level control over the CLI itself.
     - **Editing commands:** Delete with `x`, change with `c`, insert with `i`, `a`, `o`, `O`; complex operations like `dd`, `cc`, `dw`, `cw`
     - **Count support:** Prefix commands with numbers (e.g., `3h`, `5w`, `10G`)
     - **Repeat last command:** Use `.` to repeat the last editing operation
-    - **Persistent setting:** Vim mode preference is saved to `~/.gemini/settings.json` and restored between sessions
+    - **Persistent setting:** Vim mode preference is saved to `~/.ionesco/settings.json` and restored between sessions
   - **Status indicator:** When enabled, shows `[NORMAL]` or `[INSERT]` in the footer
 
 - **`/init`**
@@ -157,8 +157,8 @@ Custom commands allow you to save and reuse your favorite or most frequently use
 
 Ionesco CLI discovers commands from two locations, loaded in a specific order:
 
-1.  **User Commands (Global):** Located in `~/.gemini/commands/`. These commands are available in any project you are working on.
-2.  **Project Commands (Local):** Located in `<your-project-root>/.gemini/commands/`. These commands are specific to the current project and can be checked into version control to be shared with your team.
+1.  **User Commands (Global):** Located in `~/.ionesco/commands/`. These commands are available in any project you are working on.
+2.  **Project Commands (Local):** Located in `<your-project-root>/.ionesco/commands/`. These commands are specific to the current project and can be checked into version control to be shared with your team.
 
 If a command in the project directory has the same name as a command in the user directory, the **project command will always be used.** This allows projects to override global commands with project-specific versions.
 
@@ -166,8 +166,8 @@ If a command in the project directory has the same name as a command in the user
 
 The name of a command is determined by its file path relative to its `commands` directory. Subdirectories are used to create namespaced commands, with the path separator (`/` or `\`) being converted to a colon (`:`).
 
-- A file at `~/.gemini/commands/test.toml` becomes the command `/test`.
-- A file at `<project>/.gemini/commands/git/commit.toml` becomes the namespaced command `/git:commit`.
+- A file at `~/.ionesco/commands/test.toml` becomes the command `/test`.
+- A file at `<project>/.ionesco/commands/git/commit.toml` becomes the namespaced command `/git:commit`.
 
 #### TOML File Format (v1)
 
@@ -243,7 +243,7 @@ If you do **not** provide any arguments (e.g., `/mycommand`), the prompt is sent
 This example shows how to create a robust command by defining a role for the model, explaining where to find the user's input, and specifying the expected format and behavior.
 
 ```toml
-# In: <project>/.gemini/commands/changelog.toml
+# In: <project>/.ionesco/commands/changelog.toml
 # Invoked via: /changelog 1.2.0 added "Support for default argument parsing."
 
 description = "Adds a new entry to the project's CHANGELOG.md file."
@@ -290,7 +290,7 @@ When a custom command attempts to execute a shell command, Ionesco CLI will now 
 This command gets the staged git diff and uses it to ask the model to write a commit message.
 
 ````toml
-# In: <project>/.gemini/commands/git/commit.toml
+# In: <project>/.ionesco/commands/git/commit.toml
 # Invoked via: /git:commit
 
 description = "Generates a Git commit message based on staged changes."
@@ -327,7 +327,7 @@ You can directly embed the content of a file or a directory listing into your pr
 This command injects the content of a _fixed_ best practices file (`docs/best-practices.md`) and uses the user's arguments to provide context for the review.
 
 ```toml
-# In: <project>/.gemini/commands/review.toml
+# In: <project>/.ionesco/commands/review.toml
 # Invoked via: /review FileCommandLoader.ts
 
 description = "Reviews the provided context using a best practice guide."
@@ -355,16 +355,16 @@ Let's create a global command that asks the model to refactor a piece of code.
 First, ensure the user commands directory exists, then create a `refactor` subdirectory for organization and the final TOML file.
 
 ```bash
-mkdir -p ~/.gemini/commands/refactor
-touch ~/.gemini/commands/refactor/pure.toml
+mkdir -p ~/.ionesco/commands/refactor
+touch ~/.ionesco/commands/refactor/pure.toml
 ```
 
 **2. Add the content to the file:**
 
-Open `~/.gemini/commands/refactor/pure.toml` in your editor and add the following content. We are including the optional `description` for best practice.
+Open `~/.ionesco/commands/refactor/pure.toml` in your editor and add the following content. We are including the optional `description` for best practice.
 
 ```toml
-# In: ~/.gemini/commands/refactor/pure.toml
+# In: ~/.ionesco/commands/refactor/pure.toml
 # This command will be invoked via: /refactor:pure
 
 description = "Asks the model to refactor the current context into a pure function."

--- a/docs/cli/configuration-v1.md
+++ b/docs/cli/configuration-v1.md
@@ -31,10 +31,10 @@ Ionesco CLI uses JSON settings files for persistent configuration. There are fou
   - **Location:** `/etc/gemini-cli/system-defaults.json` (Linux), `C:\ProgramData\gemini-cli\system-defaults.json` (Windows) or `/Library/Application Support/GeminiCli/system-defaults.json` (macOS). The path can be overridden using the `GEMINI_CLI_SYSTEM_DEFAULTS_PATH` environment variable.
   - **Scope:** Provides a base layer of system-wide default settings. These settings have the lowest precedence and are intended to be overridden by user, project, or system override settings.
 - **User settings file:**
-  - **Location:** `~/.gemini/settings.json` (where `~` is your home directory).
+  - **Location:** `~/.ionesco/settings.json` (where `~` is your home directory).
   - **Scope:** Applies to all Ionesco CLI sessions for the current user. User settings override system defaults.
 - **Project settings file:**
-  - **Location:** `.gemini/settings.json` within your project's root directory.
+  - **Location:** `.ionesco/settings.json` within your project's root directory.
   - **Scope:** Applies only when running Ionesco CLI from that specific project. Project settings override user settings and system defaults.
 - **System settings file:**
   - **Location:** `/etc/gemini-cli/settings.json` (Linux), `C:\ProgramData\gemini-cli\settings.json` (Windows) or `/Library/Application Support/GeminiCli/settings.json` (macOS). The path can be overridden using the `GEMINI_CLI_SYSTEM_SETTINGS_PATH` environment variable.
@@ -44,11 +44,11 @@ Ionesco CLI uses JSON settings files for persistent configuration. There are fou
 
 > **Note for Enterprise Users:** For guidance on deploying and managing Ionesco CLI in a corporate environment, please see the [Enterprise Configuration](./enterprise.md) documentation.
 
-### The `.gemini` directory in your project
+### The `.ionesco` directory in your project
 
-In addition to a project settings file, a project's `.gemini` directory can contain other project-specific files related to Ionesco CLI's operation, such as:
+In addition to a project settings file, a project's `.ionesco` directory can contain other project-specific files related to Ionesco CLI's operation, such as:
 
-- [Custom sandbox profiles](#sandboxing) (e.g., `.gemini/sandbox-macos-custom.sb`, `.gemini/sandbox.Dockerfile`).
+- [Custom sandbox profiles](#sandboxing) (e.g., `.ionesco/sandbox-macos-custom.sb`, `.ionesco/sandbox.Dockerfile`).
 
 ### Available settings in `settings.json`:
 
@@ -291,7 +291,7 @@ If you are experiencing performance issues with file searching (e.g., with `@` c
     ```
 
 - **`excludedProjectEnvVars`** (array of strings):
-  - **Description:** Specifies environment variables that should be excluded from being loaded from project `.env` files. This prevents project-specific environment variables (like `DEBUG=true`) from interfering with gemini-cli behavior. Variables from `.gemini/.env` files are never excluded.
+  - **Description:** Specifies environment variables that should be excluded from being loaded from project `.env` files. This prevents project-specific environment variables (like `DEBUG=true`) from interfering with gemini-cli behavior. Variables from `.ionesco/.env` files are never excluded.
   - **Default:** `["DEBUG", "DEBUG_MODE"]`
   - **Example:**
     ```json
@@ -394,7 +394,7 @@ If you are experiencing performance issues with file searching (e.g., with `@` c
 
 The CLI keeps a history of shell commands you run. To avoid conflicts between different projects, this history is stored in a project-specific directory within your user's home folder.
 
-- **Location:** `~/.gemini/tmp/<project_hash>/shell_history`
+- **Location:** `~/.ionesco/tmp/<project_hash>/shell_history`
   - `<project_hash>` is a unique identifier generated from your project's root path.
   - The history is stored in a file named `shell_history`.
 
@@ -408,7 +408,7 @@ The CLI automatically loads environment variables from an `.env` file. The loadi
 2.  If not found, it searches upwards in parent directories until it finds an `.env` file or reaches the project root (identified by a `.git` folder) or the home directory.
 3.  If still not found, it looks for `~/.env` (in the user's home directory).
 
-**Environment Variable Exclusion:** Some environment variables (like `DEBUG` and `DEBUG_MODE`) are automatically excluded from being loaded from project `.env` files to prevent interference with gemini-cli behavior. Variables from `.gemini/.env` files are never excluded. You can customize this behavior using the `excludedProjectEnvVars` setting in your `settings.json` file.
+**Environment Variable Exclusion:** Some environment variables (like `DEBUG` and `DEBUG_MODE`) are automatically excluded from being loaded from project `.env` files to prevent interference with gemini-cli behavior. Variables from `.ionesco/.env` files are never excluded. You can customize this behavior using the `excludedProjectEnvVars` setting in your `settings.json` file.
 
 - **`GEMINI_API_KEY`**:
   - Your API key for the Gemini API.
@@ -446,10 +446,10 @@ The CLI automatically loads environment variables from an `.env` file. The loadi
   - Switches the Seatbelt (`sandbox-exec`) profile on macOS.
   - `permissive-open`: (Default) Restricts writes to the project folder (and a few other folders, see `packages/cli/src/utils/sandbox-macos-permissive-open.sb`) but allows other operations.
   - `strict`: Uses a strict profile that declines operations by default.
-  - `<profile_name>`: Uses a custom profile. To define a custom profile, create a file named `sandbox-macos-<profile_name>.sb` in your project's `.gemini/` directory (e.g., `my-project/.gemini/sandbox-macos-custom.sb`).
+  - `<profile_name>`: Uses a custom profile. To define a custom profile, create a file named `sandbox-macos-<profile_name>.sb` in your project's `.ionesco/` directory (e.g., `my-project/.ionesco/sandbox-macos-custom.sb`).
 - **`DEBUG` or `DEBUG_MODE`** (often used by underlying libraries or the CLI itself):
   - Set to `true` or `1` to enable verbose debug logging, which can be helpful for troubleshooting.
-  - **Note:** These variables are automatically excluded from project `.env` files by default to prevent interference with gemini-cli behavior. Use `.gemini/.env` files if you need to set these for gemini-cli specifically.
+  - **Note:** These variables are automatically excluded from project `.env` files by default to prevent interference with gemini-cli behavior. Use `.ionesco/.env` files if you need to set these for gemini-cli specifically.
 - **`NO_COLOR`**:
   - Set to any value to disable all color output in the CLI.
 - **`CLI_TITLE`**:
@@ -570,7 +570,7 @@ This example demonstrates how you can provide general project context, specific 
 
 - **Hierarchical Loading and Precedence:** The CLI implements a sophisticated hierarchical memory system by loading context files (e.g., `GEMINI.md`) from several locations. Content from files lower in this list (more specific) typically overrides or supplements content from files higher up (more general). The exact concatenation order and final context can be inspected using the `/memory show` command. The typical loading order is:
   1.  **Global Context File:**
-      - Location: `~/.gemini/<contextFileName>` (e.g., `~/.gemini/GEMINI.md` in your user home directory).
+      - Location: `~/.ionesco/<contextFileName>` (e.g., `~/.ionesco/GEMINI.md` in your user home directory).
       - Scope: Provides default instructions for all your projects.
   2.  **Project Root & Ancestors Context Files:**
       - Location: The CLI searches for the configured context file in the current working directory and then in each parent directory up to either the project root (identified by a `.git` folder) or your home directory.
@@ -599,7 +599,7 @@ Sandboxing is disabled by default, but you can enable it in a few ways:
 
 By default, it uses a pre-built `gemini-cli-sandbox` Docker image.
 
-For project-specific sandboxing needs, you can create a custom Dockerfile at `.gemini/sandbox.Dockerfile` in your project's root directory. This Dockerfile can be based on the base sandbox image:
+For project-specific sandboxing needs, you can create a custom Dockerfile at `.ionesco/sandbox.Dockerfile` in your project's root directory. This Dockerfile can be based on the base sandbox image:
 
 ```dockerfile
 FROM gemini-cli-sandbox
@@ -610,7 +610,7 @@ FROM gemini-cli-sandbox
 # COPY ./my-config /app/my-config
 ```
 
-When `.gemini/sandbox.Dockerfile` exists, you can use `BUILD_SANDBOX` environment variable when running Ionesco CLI to automatically build the custom sandbox image:
+When `.ionesco/sandbox.Dockerfile` exists, you can use `BUILD_SANDBOX` environment variable when running Ionesco CLI to automatically build the custom sandbox image:
 
 ```bash
 BUILD_SANDBOX=1 gemini -s

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -31,10 +31,10 @@ Ionesco CLI uses JSON settings files for persistent configuration. There are fou
   - **Location:** `/etc/gemini-cli/system-defaults.json` (Linux), `C:\ProgramData\gemini-cli\system-defaults.json` (Windows) or `/Library/Application Support/GeminiCli/system-defaults.json` (macOS). The path can be overridden using the `GEMINI_CLI_SYSTEM_DEFAULTS_PATH` environment variable.
   - **Scope:** Provides a base layer of system-wide default settings. These settings have the lowest precedence and are intended to be overridden by user, project, or system override settings.
 - **User settings file:**
-  - **Location:** `~/.gemini/settings.json` (where `~` is your home directory).
+  - **Location:** `~/.ionesco/settings.json` (where `~` is your home directory).
   - **Scope:** Applies to all Ionesco CLI sessions for the current user. User settings override system defaults.
 - **Project settings file:**
-  - **Location:** `.gemini/settings.json` within your project's root directory.
+  - **Location:** `.ionesco/settings.json` within your project's root directory.
   - **Scope:** Applies only when running Ionesco CLI from that specific project. Project settings override user settings and system defaults.
 - **System settings file:**
   - **Location:** `/etc/gemini-cli/settings.json` (Linux), `C:\ProgramData\gemini-cli\settings.json` (Windows) or `/Library/Application Support/GeminiCli/settings.json` (macOS). The path can be overridden using the `GEMINI_CLI_SYSTEM_SETTINGS_PATH` environment variable.
@@ -44,11 +44,11 @@ Ionesco CLI uses JSON settings files for persistent configuration. There are fou
 
 > **Note for Enterprise Users:** For guidance on deploying and managing Ionesco CLI in a corporate environment, please see the [Enterprise Configuration](./enterprise.md) documentation.
 
-### The `.gemini` directory in your project
+### The `.ionesco` directory in your project
 
-In addition to a project settings file, a project's `.gemini` directory can contain other project-specific files related to Ionesco CLI's operation, such as:
+In addition to a project settings file, a project's `.ionesco` directory can contain other project-specific files related to Ionesco CLI's operation, such as:
 
-- [Custom sandbox profiles](#sandboxing) (e.g., `.gemini/sandbox-macos-custom.sb`, `.gemini/sandbox.Dockerfile`).
+- [Custom sandbox profiles](#sandboxing) (e.g., `.ionesco/sandbox-macos-custom.sb`, `.ionesco/sandbox.Dockerfile`).
 
 ### Available settings in `settings.json`
 
@@ -376,7 +376,7 @@ Here is an example of a `settings.json` file with the nested structure, new as o
 
 The CLI keeps a history of shell commands you run. To avoid conflicts between different projects, this history is stored in a project-specific directory within your user's home folder.
 
-- **Location:** `~/.gemini/tmp/<project_hash>/shell_history`
+- **Location:** `~/.ionesco/tmp/<project_hash>/shell_history`
   - `<project_hash>` is a unique identifier generated from your project's root path.
   - The history is stored in a file named `shell_history`.
 
@@ -390,7 +390,7 @@ The CLI automatically loads environment variables from an `.env` file. The loadi
 2.  If not found, it searches upwards in parent directories until it finds an `.env` file or reaches the project root (identified by a `.git` folder) or the home directory.
 3.  If still not found, it looks for `~/.env` (in the user's home directory).
 
-**Environment Variable Exclusion:** Some environment variables (like `DEBUG` and `DEBUG_MODE`) are automatically excluded from being loaded from project `.env` files to prevent interference with gemini-cli behavior. Variables from `.gemini/.env` files are never excluded. You can customize this behavior using the `advanced.excludedEnvVars` setting in your `settings.json` file.
+**Environment Variable Exclusion:** Some environment variables (like `DEBUG` and `DEBUG_MODE`) are automatically excluded from being loaded from project `.env` files to prevent interference with gemini-cli behavior. Variables from `.ionesco/.env` files are never excluded. You can customize this behavior using the `advanced.excludedEnvVars` setting in your `settings.json` file.
 
 - **`GEMINI_API_KEY`**:
   - Your API key for the Gemini API.
@@ -437,10 +437,10 @@ The CLI automatically loads environment variables from an `.env` file. The loadi
   - Switches the Seatbelt (`sandbox-exec`) profile on macOS.
   - `permissive-open`: (Default) Restricts writes to the project folder (and a few other folders, see `packages/cli/src/utils/sandbox-macos-permissive-open.sb`) but allows other operations.
   - `strict`: Uses a strict profile that declines operations by default.
-  - `<profile_name>`: Uses a custom profile. To define a custom profile, create a file named `sandbox-macos-<profile_name>.sb` in your project's `.gemini/` directory (e.g., `my-project/.gemini/sandbox-macos-custom.sb`).
+  - `<profile_name>`: Uses a custom profile. To define a custom profile, create a file named `sandbox-macos-<profile_name>.sb` in your project's `.ionesco/` directory (e.g., `my-project/.ionesco/sandbox-macos-custom.sb`).
 - **`DEBUG` or `DEBUG_MODE`** (often used by underlying libraries or the CLI itself):
   - Set to `true` or `1` to enable verbose debug logging, which can be helpful for troubleshooting.
-  - **Note:** These variables are automatically excluded from project `.env` files by default to prevent interference with gemini-cli behavior. Use `.gemini/.env` files if you need to set these for gemini-cli specifically.
+  - **Note:** These variables are automatically excluded from project `.env` files by default to prevent interference with gemini-cli behavior. Use `.ionesco/.env` files if you need to set these for gemini-cli specifically.
 - **`NO_COLOR`**:
   - Set to any value to disable all color output in the CLI.
 - **`CLI_TITLE`**:
@@ -568,7 +568,7 @@ This example demonstrates how you can provide general project context, specific 
 
 - **Hierarchical Loading and Precedence:** The CLI implements a sophisticated hierarchical memory system by loading context files (e.g., `GEMINI.md`) from several locations. Content from files lower in this list (more specific) typically overrides or supplements content from files higher up (more general). The exact concatenation order and final context can be inspected using the `/memory show` command. The typical loading order is:
   1.  **Global Context File:**
-      - Location: `~/.gemini/<configured-context-filename>` (e.g., `~/.gemini/GEMINI.md` in your user home directory).
+      - Location: `~/.ionesco/<configured-context-filename>` (e.g., `~/.ionesco/GEMINI.md` in your user home directory).
       - Scope: Provides default instructions for all your projects.
   2.  **Project Root & Ancestors Context Files:**
       - Location: The CLI searches for the configured context file in the current working directory and then in each parent directory up to either the project root (identified by a `.git` folder) or your home directory.
@@ -597,7 +597,7 @@ Sandboxing is disabled by default, but you can enable it in a few ways:
 
 By default, it uses a pre-built `gemini-cli-sandbox` Docker image.
 
-For project-specific sandboxing needs, you can create a custom Dockerfile at `.gemini/sandbox.Dockerfile` in your project's root directory. This Dockerfile can be based on the base sandbox image:
+For project-specific sandboxing needs, you can create a custom Dockerfile at `.ionesco/sandbox.Dockerfile` in your project's root directory. This Dockerfile can be based on the base sandbox image:
 
 ```dockerfile
 FROM gemini-cli-sandbox
@@ -608,7 +608,7 @@ FROM gemini-cli-sandbox
 # COPY ./my-config /app/my-config
 ```
 
-When `.gemini/sandbox.Dockerfile` exists, you can use `BUILD_SANDBOX` environment variable when running Ionesco CLI to automatically build the custom sandbox image:
+When `.ionesco/sandbox.Dockerfile` exists, you can use `BUILD_SANDBOX` environment variable when running Ionesco CLI to automatically build the custom sandbox image:
 
 ```bash
 BUILD_SANDBOX=1 gemini -s

--- a/docs/cli/enterprise.md
+++ b/docs/cli/enterprise.md
@@ -11,8 +11,8 @@ The most powerful tools for enterprise administration are the system-wide settin
 Settings are merged from four files. The precedence order for single-value settings (like `theme`) is:
 
 1. System Defaults (`system-defaults.json`)
-2. User Settings (`~/.gemini/settings.json`)
-3. Workspace Settings (`<project>/.gemini/settings.json`)
+2. User Settings (`~/.ionesco/settings.json`)
+3. Workspace Settings (`<project>/.ionesco/settings.json`)
 4. System Overrides (`settings.json`)
 
 This means the System Overrides file has the final say. For settings that are arrays (`includeDirectories`) or objects (`mcpServers`), the values are merged.
@@ -34,7 +34,7 @@ Here is how settings from different levels are combined.
   }
   ```
 
-- **User `settings.json` (`~/.gemini/settings.json`):**
+- **User `settings.json` (`~/.ionesco/settings.json`):**
 
   ```json
   {
@@ -55,7 +55,7 @@ Here is how settings from different levels are combined.
   }
   ```
 
-- **Workspace `settings.json` (`<project>/.gemini/settings.json`):**
+- **Workspace `settings.json` (`<project>/.ionesco/settings.json`):**
 
   ```json
   {

--- a/docs/cli/tutorials.md
+++ b/docs/cli/tutorials.md
@@ -24,7 +24,7 @@ Before you begin, ensure you have the following installed and configured:
 
 #### Configure the MCP server in `settings.json`
 
-In your project's root directory, create or open the [`.gemini/settings.json` file](./configuration.md). Within the file, add the `mcpServers` configuration block, which provides instructions for how to launch the GitHub MCP server.
+In your project's root directory, create or open the [`.ionesco/settings.json` file](./configuration.md). Within the file, add the `mcpServers` configuration block, which provides instructions for how to launch the GitHub MCP server.
 
 ```json
 {

--- a/docs/extension.md
+++ b/docs/extension.md
@@ -80,11 +80,11 @@ gemini extensions link path/to/directory
 
 ## How it works
 
-On startup, Ionesco CLI looks for extensions in `<home>/.gemini/extensions`
+On startup, Ionesco CLI looks for extensions in `<home>/.ionesco/extensions`
 
 Extensions exist as a directory that contains a `gemini-extension.json` file. For example:
 
-`<home>/.gemini/extensions/my-extension/gemini-extension.json`
+`<home>/.ionesco/extensions/my-extension/gemini-extension.json`
 
 ### `gemini-extension.json`
 
@@ -122,7 +122,7 @@ Extensions can provide [custom commands](./cli/commands.md#custom-commands) by p
 An extension named `gcp` with the following structure:
 
 ```
-.gemini/extensions/gcp/
+.ionesco/extensions/gcp/
 ├── gemini-extension.json
 └── commands/
     ├── deploy.toml
@@ -153,8 +153,8 @@ Ionesco CLI extensions allow variable substitution in `gemini-extension.json`. T
 
 **Supported variables:**
 
-| variable                   | description                                                                                                                                                     |
-| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `${extensionPath}`         | The fully-qualified path of the extension in the user's filesystem e.g., '/Users/username/.gemini/extensions/example-extension'. This will not unwrap symlinks. |
-| `${workspacePath}`         | The fully-qualified path of the current workspace.                                                                                                              |
-| `${/} or ${pathSeparator}` | The path separator (differs per OS).                                                                                                                            |
+| variable                   | description                                                                                                                                                      |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `${extensionPath}`         | The fully-qualified path of the extension in the user's filesystem e.g., '/Users/username/.ionesco/extensions/example-extension'. This will not unwrap symlinks. |
+| `${workspacePath}`         | The fully-qualified path of the current workspace.                                                                                                               |
+| `${/} or ${pathSeparator}` | The path separator (differs per OS).                                                                                                                             |

--- a/docs/ide-companion-spec.md
+++ b/docs/ide-companion-spec.md
@@ -2,7 +2,7 @@
 
 > Last Updated: September 15, 2025
 
-This document defines the contract for building a companion extension to enable Ionesco CLI's IDE mode. For VS Code, these features (native diffing, context awareness) are provided by the official extension ([marketplace](https://marketplace.visualstudio.com/items?itemName=Google.gemini-cli-vscode-ide-companion)). This specification is for contributors who wish to bring similar functionality to other editors like JetBrains IDEs, Sublime Text, etc.
+This document defines the contract for building a companion extension to enable Ionesco CLI's IDE mode. For VS Code, these features (native diffing, context awareness) are provided by the official extension ([marketplace](https://marketplace.visualstudio.com/items?itemName=Google.ionesco-cli-vscode-ide-companion)). This specification is for contributors who wish to bring similar functionality to other editors like JetBrains IDEs, Sublime Text, etc.
 
 ## I. The Communication Interface
 

--- a/docs/ide-integration.md
+++ b/docs/ide-integration.md
@@ -43,7 +43,7 @@ This will find the correct extension for your IDE and install it.
 
 You can also install the extension directly from a marketplace.
 
-- **For Visual Studio Code:** Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=google.gemini-cli-vscode-ide-companion).
+- **For Visual Studio Code:** Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=google.ionesco-cli-vscode-ide-companion).
 - **For VS Code Forks:** To support forks of VS Code, the extension is also published on the [Open VSX Registry](https://open-vsx.org/extension/google/gemini-cli-vscode-ide-companion). Follow your editor's instructions for installing extensions from this registry.
 
 > NOTE:

--- a/docs/providers/grok.md
+++ b/docs/providers/grok.md
@@ -23,7 +23,7 @@ Google Gemini provider while the CLI is running.
 
    ```bash
    npm install
-   ./scripts/setup.sh
+   ./setup.sh
    ```
 
    The setup script creates a dedicated virtual environment under
@@ -51,7 +51,7 @@ Google Gemini provider while the CLI is running.
 Use the platform helper script so the correct virtual environment is detected:
 
 ```bash
-./scripts/start.sh          # Unix
+./start.sh          # Unix
 scripts\start.bat           # Windows PowerShell / CMD
 ```
 
@@ -80,7 +80,7 @@ confirm which backend is responding.
   explicitly to the interpreter path.
 - **Tool call appears to hang** – tail `grok-debug.log` (or the file named in
   `GROK_DEBUG_LOG_FILE`) to confirm the sidecar is receiving tool results. If
-  necessary, rerun `./scripts/setup.sh` to upgrade the `xai-sdk` dependencies.
+  necessary, rerun `./setup.sh` to upgrade the `xai-sdk` dependencies.
 
 For deeper implementation details see
 [docs/design/grok-provider.md](../design/grok-provider.md).

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -131,7 +131,7 @@ export SANDBOX_SET_UID_GID=false  # Disable UID/GID mapping
 DEBUG=1 gemini -s -p "debug command"
 ```
 
-**Note:** If you have `DEBUG=true` in a project's `.env` file, it won't affect gemini-cli due to automatic exclusion. Use `.gemini/.env` files for gemini-cli specific debug settings.
+**Note:** If you have `DEBUG=true` in a project's `.env` file, it won't affect gemini-cli due to automatic exclusion. Use `.ionesco/.env` files for gemini-cli specific debug settings.
 
 ### Inspect sandbox
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -48,7 +48,7 @@ observability framework — Ionesco CLI's observability system provides:
 
 ## Configuration
 
-All telemetry behavior is controlled through your `.gemini/settings.json` file
+All telemetry behavior is controlled through your `.ionesco/settings.json` file
 and can be overridden with CLI flags:
 
 | Setting        | Values            | Default                 | CLI Override                                             | Description                                          |
@@ -107,7 +107,7 @@ Before using either method below, complete these steps:
 
 Sends telemetry directly to Google Cloud services. No collector needed.
 
-1. Enable telemetry in your `.gemini/settings.json`:
+1. Enable telemetry in your `.ionesco/settings.json`:
    ```json
    {
      "telemetry": {
@@ -128,7 +128,7 @@ Sends telemetry directly to Google Cloud services. No collector needed.
 For custom processing, filtering, or routing, use an OpenTelemetry collector to
 forward data to Google Cloud.
 
-1. Configure your `.gemini/settings.json`:
+1. Configure your `.ionesco/settings.json`:
    ```json
    {
      "telemetry": {
@@ -146,7 +146,7 @@ forward data to Google Cloud.
    - Start a local OTEL collector that forwards to Google Cloud
    - Configure your workspace
    - Provide links to view traces, metrics, and logs in Google Cloud Console
-   - Save collector logs to `~/.gemini/tmp/<projectHash>/otel/collector-gcp.log`
+   - Save collector logs to `~/.ionesco/tmp/<projectHash>/otel/collector-gcp.log`
    - Stop collector on exit (e.g. `Ctrl+C`)
 3. Run Ionesco CLI and send prompts.
 4. View logs and metrics:
@@ -154,7 +154,7 @@ forward data to Google Cloud.
      - Logs: https://console.cloud.google.com/logs/
      - Metrics: https://console.cloud.google.com/monitoring/metrics-explorer
      - Traces: https://console.cloud.google.com/traces/list
-   - Open `~/.gemini/tmp/<projectHash>/otel/collector-gcp.log` to view local
+   - Open `~/.ionesco/tmp/<projectHash>/otel/collector-gcp.log` to view local
      collector logs.
 
 ## Local Telemetry
@@ -163,19 +163,19 @@ For local development and debugging, you can capture telemetry data locally:
 
 ### File-based Output (Recommended)
 
-1. Enable telemetry in your `.gemini/settings.json`:
+1. Enable telemetry in your `.ionesco/settings.json`:
    ```json
    {
      "telemetry": {
        "enabled": true,
        "target": "local",
        "otlpEndpoint": "",
-       "outfile": ".gemini/telemetry.log"
+       "outfile": ".ionesco/telemetry.log"
      }
    }
    ```
 2. Run Ionesco CLI and send prompts.
-3. View logs and metrics in the specified file (e.g., `.gemini/telemetry.log`).
+3. View logs and metrics in the specified file (e.g., `.ionesco/telemetry.log`).
 
 ### Collector-Based Export (Advanced)
 
@@ -187,7 +187,7 @@ For local development and debugging, you can capture telemetry data locally:
    - Download and start Jaeger and OTEL collector
    - Configure your workspace for local telemetry
    - Provide a Jaeger UI at http://localhost:16686
-   - Save logs/metrics to `~/.gemini/tmp/<projectHash>/otel/collector.log`
+   - Save logs/metrics to `~/.ionesco/tmp/<projectHash>/otel/collector.log`
    - Stop collector on exit (e.g. `Ctrl+C`)
 2. Run Ionesco CLI and send prompts.
 3. View traces at http://localhost:16686 and logs/metrics in the collector log

--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -198,7 +198,7 @@ Use the `/mcp auth` command to manage OAuth authentication:
 
 OAuth tokens are automatically:
 
-- **Stored securely** in `~/.gemini/mcp-oauth-tokens.json`
+- **Stored securely** in `~/.ionesco/mcp-oauth-tokens.json`
 - **Refreshed** when expired (if refresh tokens are available)
 - **Validated** before each connection attempt
 - **Cleaned up** when invalid or expired
@@ -722,7 +722,7 @@ While you can always configure MCP servers by manually editing your `settings.js
 
 ### Adding a Server (`gemini mcp add`)
 
-The `add` command configures a new MCP server in your `settings.json`. Based on the scope (`-s, --scope`), it will be added to either the user config `~/.gemini/settings.json` or the project config `.gemini/settings.json` file.
+The `add` command configures a new MCP server in your `settings.json`. Based on the scope (`-s, --scope`), it will be added to either the user config `~/.ionesco/settings.json` or the project config `.ionesco/settings.json` file.
 
 **Command:**
 

--- a/docs/tools/memory.md
+++ b/docs/tools/memory.md
@@ -14,7 +14,7 @@ Use `save_memory` to save and recall information across your Ionesco CLI session
 
 ## How to use `save_memory` with the Ionesco CLI
 
-The tool appends the provided `fact` to a special `GEMINI.md` file located in the user's home directory (`~/.gemini/GEMINI.md`). This file can be configured to have a different name.
+The tool appends the provided `fact` to a special `GEMINI.md` file located in the user's home directory (`~/.ionesco/GEMINI.md`). This file can be configured to have a different name.
 
 Once added, the facts are stored under a `## Gemini Added Memories` section. This file is loaded as context in subsequent sessions, allowing the CLI to recall the saved information.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -31,8 +31,8 @@ This guide provides solutions to common issues and debugging tips, including top
 
 - **Q: Where are the Ionesco CLI configuration or settings files stored?**
   - A: The Ionesco CLI configuration is stored in two `settings.json` files:
-    1. In your home directory: `~/.gemini/settings.json`.
-    2. In your project's root directory: `./.gemini/settings.json`.
+    1. In your home directory: `~/.ionesco/settings.json`.
+    2. In your project's root directory: `./.ionesco/settings.json`.
 
     Refer to [Ionesco CLI Configuration](./cli/configuration.md) for more details.
 
@@ -72,7 +72,7 @@ This guide provides solutions to common issues and debugging tips, including top
 - **DEBUG mode not working from project .env file**
   - **Issue:** Setting `DEBUG=true` in a project's `.env` file doesn't enable debug mode for gemini-cli.
   - **Cause:** The `DEBUG` and `DEBUG_MODE` variables are automatically excluded from project `.env` files to prevent interference with gemini-cli behavior.
-  - **Solution:** Use a `.gemini/.env` file instead, or configure the `advanced.excludedEnvVars` setting in your `settings.json` to exclude fewer variables.
+  - **Solution:** Use a `.ionesco/.env` file instead, or configure the `advanced.excludedEnvVars` setting in your `settings.json` to exclude fewer variables.
 
 ## Exit Codes
 

--- a/integration-tests/test-helper.ts
+++ b/integration-tests/test-helper.ts
@@ -138,7 +138,7 @@ export class TestRig {
     mkdirSync(this.testDir, { recursive: true });
 
     // Create a settings file to point the CLI to the local collector
-    const geminiDir = join(this.testDir, '.gemini');
+    const geminiDir = join(this.testDir, '.ionesco');
     mkdirSync(geminiDir, { recursive: true });
     // In sandbox mode, use an absolute path for telemetry inside the container
     // The container mounts the test directory at the same path as the host

--- a/packages/a2a-server/src/config/extension.ts
+++ b/packages/a2a-server/src/config/extension.ts
@@ -12,7 +12,7 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import { logger } from '../utils/logger.js';
 
-export const EXTENSIONS_DIRECTORY_NAME = path.join('.gemini', 'extensions');
+export const EXTENSIONS_DIRECTORY_NAME = path.join('.ionesco', 'extensions');
 export const EXTENSIONS_CONFIG_FILENAME = 'gemini-extension.json';
 
 export interface Extension {

--- a/packages/a2a-server/src/config/settings.ts
+++ b/packages/a2a-server/src/config/settings.ts
@@ -15,7 +15,7 @@ import {
 } from '@google/gemini-cli-core';
 import stripJsonComments from 'strip-json-comments';
 
-export const SETTINGS_DIRECTORY_NAME = '.gemini';
+export const SETTINGS_DIRECTORY_NAME = '.ionesco';
 export const USER_SETTINGS_DIR = path.join(homedir(), SETTINGS_DIRECTORY_NAME);
 export const USER_SETTINGS_PATH = path.join(USER_SETTINGS_DIR, 'settings.json');
 

--- a/packages/cli/src/commands/mcp/list.test.ts
+++ b/packages/cli/src/commands/mcp/list.test.ts
@@ -29,7 +29,7 @@ vi.mock('@google/gemini-cli-core', () => ({
     getWorkspaceSettingsPath: () => '/tmp/gemini/workspace-settings.json',
     getProjectTempDir: () => '/test/home/.gemini/tmp/mocked_hash',
   })),
-  GEMINI_CONFIG_DIR: '.gemini',
+  GEMINI_CONFIG_DIR: '.ionesco',
   getErrorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
 }));
 vi.mock('@modelcontextprotocol/sdk/client/index.js');

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -752,7 +752,7 @@ describe('Hierarchical Memory Loading (config.ts) - Placeholder Suite', () => {
   // 3. Spies on console functions (for logger output) are correctly set up if needed.
   // Example of a previously failing test structure:
   it.skip('should correctly use mocked homedir for global path', async () => {
-    const MOCK_GEMINI_DIR_LOCAL = path.join('/mock/home/user', '.gemini');
+    const MOCK_GEMINI_DIR_LOCAL = path.join('/mock/home/user', '.ionesco');
     const MOCK_GLOBAL_PATH_LOCAL = path.join(
       MOCK_GEMINI_DIR_LOCAL,
       'GEMINI.md',

--- a/packages/cli/src/config/extension.ts
+++ b/packages/cli/src/config/extension.ts
@@ -36,7 +36,7 @@ import { ExtensionEnablementManager } from './extensions/extensionEnablement.js'
 export const EXTENSIONS_DIRECTORY_NAME = path.join(GEMINI_DIR, 'extensions');
 
 export const EXTENSIONS_CONFIG_FILENAME = 'gemini-extension.json';
-export const INSTALL_METADATA_FILENAME = '.gemini-extension-install.json';
+export const INSTALL_METADATA_FILENAME = '.ionesco-extension-install.json';
 
 export interface Extension {
   path: string;

--- a/packages/cli/src/config/extensions/extensionEnablement.test.ts
+++ b/packages/cli/src/config/extensions/extensionEnablement.test.ts
@@ -26,7 +26,7 @@ let manager: ExtensionEnablementManager;
 describe('ExtensionEnablementManager', () => {
   beforeEach(() => {
     testDir = createTestDir();
-    configDir = path.join(testDir.path, '.gemini');
+    configDir = path.join(testDir.path, '.ionesco');
     manager = new ExtensionEnablementManager(configDir);
   });
 

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -49,7 +49,7 @@ function getMergeStrategyForPath(path: string[]): MergeStrategy | undefined {
 
 export type { Settings, MemoryImportFormat };
 
-export const SETTINGS_DIRECTORY_NAME = '.gemini';
+export const SETTINGS_DIRECTORY_NAME = '.ionesco';
 
 export const USER_SETTINGS_PATH = Storage.getGlobalSettingsPath();
 export const USER_SETTINGS_DIR = path.dirname(USER_SETTINGS_PATH);

--- a/packages/cli/src/config/trustedFolders.ts
+++ b/packages/cli/src/config/trustedFolders.ts
@@ -16,7 +16,7 @@ import type { Settings } from './settings.js';
 import stripJsonComments from 'strip-json-comments';
 
 export const TRUSTED_FOLDERS_FILENAME = 'trustedFolders.json';
-export const SETTINGS_DIRECTORY_NAME = '.gemini';
+export const SETTINGS_DIRECTORY_NAME = '.ionesco';
 export const USER_SETTINGS_DIR = path.join(homedir(), SETTINGS_DIRECTORY_NAME);
 
 export function getTrustedFoldersPath(): string {

--- a/packages/cli/src/services/FileCommandLoader.test.ts
+++ b/packages/cli/src/services/FileCommandLoader.test.ts
@@ -529,7 +529,7 @@ describe('FileCommandLoader', () => {
       ).getProjectCommandsDir();
       const extensionDir = path.join(
         process.cwd(),
-        '.gemini/extensions/test-ext',
+        '.ionesco/extensions/test-ext',
       );
 
       mock({
@@ -582,7 +582,7 @@ describe('FileCommandLoader', () => {
       ).getProjectCommandsDir();
       const extensionDir = path.join(
         process.cwd(),
-        '.gemini/extensions/test-ext',
+        '.ionesco/extensions/test-ext',
       );
 
       mock({
@@ -678,11 +678,11 @@ describe('FileCommandLoader', () => {
     it('only loads commands from active extensions', async () => {
       const extensionDir1 = path.join(
         process.cwd(),
-        '.gemini/extensions/active-ext',
+        '.ionesco/extensions/active-ext',
       );
       const extensionDir2 = path.join(
         process.cwd(),
-        '.gemini/extensions/inactive-ext',
+        '.ionesco/extensions/inactive-ext',
       );
 
       mock({
@@ -737,7 +737,7 @@ describe('FileCommandLoader', () => {
     it('handles missing extension commands directory gracefully', async () => {
       const extensionDir = path.join(
         process.cwd(),
-        '.gemini/extensions/no-commands',
+        '.ionesco/extensions/no-commands',
       );
 
       mock({
@@ -769,7 +769,7 @@ describe('FileCommandLoader', () => {
     });
 
     it('handles nested command structure in extensions', async () => {
-      const extensionDir = path.join(process.cwd(), '.gemini/extensions/a');
+      const extensionDir = path.join(process.cwd(), '.ionesco/extensions/a');
 
       mock({
         [extensionDir]: {

--- a/packages/cli/src/ui/commands/restoreCommand.test.ts
+++ b/packages/cli/src/ui/commands/restoreCommand.test.ts
@@ -26,7 +26,7 @@ describe('restoreCommand', () => {
     testRootDir = await fs.mkdtemp(
       path.join(os.tmpdir(), 'restore-command-test-'),
     );
-    geminiTempDir = path.join(testRootDir, '.gemini');
+    geminiTempDir = path.join(testRootDir, '.ionesco');
     checkpointsDir = path.join(geminiTempDir, 'checkpoints');
     // The command itself creates this, but for tests it's easier to have it ready.
     // Some tests might remove it to test error paths.

--- a/packages/cli/src/ui/commands/setupGithubCommand.test.ts
+++ b/packages/cli/src/ui/commands/setupGithubCommand.test.ts
@@ -112,7 +112,7 @@ describe('setupGithubCommand', async () => {
 
     if (gitignoreExists) {
       const gitignoreContent = await fs.readFile(gitignorePath, 'utf8');
-      expect(gitignoreContent).toContain('.gemini/');
+      expect(gitignoreContent).toContain('.ionesco/');
       expect(gitignoreContent).toContain('gha-creds-*.json');
     }
   });
@@ -135,7 +135,7 @@ describe('updateGitignore', () => {
     const gitignorePath = path.join(scratchDir, '.gitignore');
     const content = await fs.readFile(gitignorePath, 'utf8');
 
-    expect(content).toBe('.gemini/\ngha-creds-*.json\n');
+    expect(content).toBe('.ionesco/\ngha-creds-*.json\n');
   });
 
   it('appends entries to existing .gitignore file', async () => {
@@ -154,7 +154,7 @@ describe('updateGitignore', () => {
 
   it('does not add duplicate entries', async () => {
     const gitignorePath = path.join(scratchDir, '.gitignore');
-    const existingContent = '.gemini/\nsome-other-file\ngha-creds-*.json\n';
+    const existingContent = '.ionesco/\nsome-other-file\ngha-creds-*.json\n';
     await fs.writeFile(gitignorePath, existingContent);
 
     await updateGitignore(scratchDir);
@@ -166,7 +166,7 @@ describe('updateGitignore', () => {
 
   it('adds only missing entries when some already exist', async () => {
     const gitignorePath = path.join(scratchDir, '.gitignore');
-    const existingContent = '.gemini/\nsome-other-file\n';
+    const existingContent = '.ionesco/\nsome-other-file\n';
     await fs.writeFile(gitignorePath, existingContent);
 
     await updateGitignore(scratchDir);
@@ -174,7 +174,7 @@ describe('updateGitignore', () => {
     const content = await fs.readFile(gitignorePath, 'utf8');
 
     // Should add only the missing gha-creds-*.json entry
-    expect(content).toBe('.gemini/\nsome-other-file\n\ngha-creds-*.json\n');
+    expect(content).toBe('.ionesco/\nsome-other-file\n\ngha-creds-*.json\n');
     expect(content).toContain('gha-creds-*.json');
     // Should not duplicate .gemini/ entry
     expect((content.match(/\.gemini\//g) || []).length).toBe(1);
@@ -196,7 +196,7 @@ describe('updateGitignore', () => {
     const content = await fs.readFile(gitignorePath, 'utf8');
 
     // Should add both entries since they don't actually exist as gitignore rules
-    expect(content).toContain('.gemini/');
+    expect(content).toContain('.ionesco/');
     expect(content).toContain('gha-creds-*.json');
 
     // Verify the entries were added (not just mentioned in comments)
@@ -204,7 +204,7 @@ describe('updateGitignore', () => {
       .split('\n')
       .map((line) => line.split('#')[0].trim())
       .filter((line) => line);
-    expect(lines).toContain('.gemini/');
+    expect(lines).toContain('.ionesco/');
     expect(lines).toContain('gha-creds-*.json');
     expect(lines).toContain('my-app.gemini/config');
     expect(lines).toContain('some-other-gha-creds-file.json');

--- a/packages/cli/src/ui/commands/setupGithubCommand.ts
+++ b/packages/cli/src/ui/commands/setupGithubCommand.ts
@@ -51,7 +51,7 @@ function getOpenUrlsCommands(readmeUrl: string): string[] {
 
 // Add Ionesco CLI specific entries to .gitignore file
 export async function updateGitignore(gitRepoRoot: string): Promise<void> {
-  const gitignoreEntries = ['.gemini/', 'gha-creds-*.json'];
+  const gitignoreEntries = ['.ionesco/', 'gha-creds-*.json'];
 
   const gitignorePath = path.join(gitRepoRoot, '.gitignore');
   try {

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -445,7 +445,7 @@ describe('InputPrompt', () => {
     it('should insert image path at cursor position with proper spacing', async () => {
       const imagePath = path.join(
         'test',
-        '.gemini-clipboard',
+        '.ionesco-clipboard',
         'clipboard-456.png',
       );
       vi.mocked(clipboardUtils.clipboardHasImage).mockResolvedValue(true);

--- a/packages/cli/src/ui/hooks/useShellHistory.test.ts
+++ b/packages/cli/src/ui/hooks/useShellHistory.test.ts
@@ -28,12 +28,12 @@ vi.mock('fs', async (importOriginal) => {
 vi.mock('@google/gemini-cli-core', () => {
   class Storage {
     getProjectTempDir(): string {
-      return path.join('/test/home/', '.gemini', 'tmp', 'mocked_hash');
+      return path.join('/test/home/', '.ionesco', 'tmp', 'mocked_hash');
     }
     getHistoryFilePath(): string {
       return path.join(
         '/test/home/',
-        '.gemini',
+        '.ionesco',
         'tmp',
         'mocked_hash',
         'shell_history',
@@ -53,7 +53,7 @@ const MOCKED_PROJECT_HASH = 'mocked_hash';
 
 const MOCKED_HISTORY_DIR = path.join(
   MOCKED_HOME_DIR,
-  '.gemini',
+  '.ionesco',
   'tmp',
   MOCKED_PROJECT_HASH,
 );

--- a/packages/cli/src/ui/utils/clipboardUtils.ts
+++ b/packages/cli/src/ui/utils/clipboardUtils.ts
@@ -44,7 +44,7 @@ export async function saveClipboardImage(
     // Create a temporary directory for clipboard images within the target directory
     // This avoids security restrictions on paths outside the target directory
     const baseDir = targetDir || process.cwd();
-    const tempDir = path.join(baseDir, '.gemini-clipboard');
+    const tempDir = path.join(baseDir, '.ionesco-clipboard');
     await fs.mkdir(tempDir, { recursive: true });
 
     // Generate a unique filename with timestamp
@@ -120,7 +120,7 @@ export async function cleanupOldClipboardImages(
 ): Promise<void> {
   try {
     const baseDir = targetDir || process.cwd();
-    const tempDir = path.join(baseDir, '.gemini-clipboard');
+    const tempDir = path.join(baseDir, '.ionesco-clipboard');
     const files = await fs.readdir(tempDir);
     const oneHourAgo = Date.now() - 60 * 60 * 1000;
 

--- a/packages/cli/src/utils/sandbox-macos-permissive-closed.sb
+++ b/packages/cli/src/utils/sandbox-macos-permissive-closed.sb
@@ -9,7 +9,7 @@
     (subpath (param "TARGET_DIR"))
     (subpath (param "TMP_DIR"))
     (subpath (param "CACHE_DIR"))
-    (subpath (string-append (param "HOME_DIR") "/.gemini"))
+    (subpath (string-append (param "HOME_DIR") "/.ionesco"))
     (subpath (string-append (param "HOME_DIR") "/.npm"))
     (subpath (string-append (param "HOME_DIR") "/.cache"))
     (subpath (string-append (param "HOME_DIR") "/.gitconfig"))

--- a/packages/cli/src/utils/sandbox-macos-permissive-open.sb
+++ b/packages/cli/src/utils/sandbox-macos-permissive-open.sb
@@ -9,7 +9,7 @@
     (subpath (param "TARGET_DIR"))
     (subpath (param "TMP_DIR"))
     (subpath (param "CACHE_DIR"))
-    (subpath (string-append (param "HOME_DIR") "/.gemini"))
+    (subpath (string-append (param "HOME_DIR") "/.ionesco"))
     (subpath (string-append (param "HOME_DIR") "/.npm"))
     (subpath (string-append (param "HOME_DIR") "/.cache"))
     (subpath (string-append (param "HOME_DIR") "/.gitconfig"))

--- a/packages/cli/src/utils/sandbox-macos-permissive-proxied.sb
+++ b/packages/cli/src/utils/sandbox-macos-permissive-proxied.sb
@@ -9,7 +9,7 @@
     (subpath (param "TARGET_DIR"))
     (subpath (param "TMP_DIR"))
     (subpath (param "CACHE_DIR"))
-    (subpath (string-append (param "HOME_DIR") "/.gemini"))
+    (subpath (string-append (param "HOME_DIR") "/.ionesco"))
     (subpath (string-append (param "HOME_DIR") "/.npm"))
     (subpath (string-append (param "HOME_DIR") "/.cache"))
     (subpath (string-append (param "HOME_DIR") "/.gitconfig"))

--- a/packages/cli/src/utils/sandbox-macos-restrictive-closed.sb
+++ b/packages/cli/src/utils/sandbox-macos-restrictive-closed.sb
@@ -67,7 +67,7 @@
     (subpath (param "TARGET_DIR"))
     (subpath (param "TMP_DIR"))
     (subpath (param "CACHE_DIR"))
-    (subpath (string-append (param "HOME_DIR") "/.gemini"))
+    (subpath (string-append (param "HOME_DIR") "/.ionesco"))
     (subpath (string-append (param "HOME_DIR") "/.npm"))
     (subpath (string-append (param "HOME_DIR") "/.cache"))
     (subpath (string-append (param "HOME_DIR") "/.gitconfig"))

--- a/packages/cli/src/utils/sandbox-macos-restrictive-open.sb
+++ b/packages/cli/src/utils/sandbox-macos-restrictive-open.sb
@@ -67,7 +67,7 @@
     (subpath (param "TARGET_DIR"))
     (subpath (param "TMP_DIR"))
     (subpath (param "CACHE_DIR"))
-    (subpath (string-append (param "HOME_DIR") "/.gemini"))
+    (subpath (string-append (param "HOME_DIR") "/.ionesco"))
     (subpath (string-append (param "HOME_DIR") "/.npm"))
     (subpath (string-append (param "HOME_DIR") "/.cache"))
     (subpath (string-append (param "HOME_DIR") "/.gitconfig"))

--- a/packages/cli/src/utils/sandbox-macos-restrictive-proxied.sb
+++ b/packages/cli/src/utils/sandbox-macos-restrictive-proxied.sb
@@ -67,7 +67,7 @@
     (subpath (param "TARGET_DIR"))
     (subpath (param "TMP_DIR"))
     (subpath (param "CACHE_DIR"))
-    (subpath (string-append (param "HOME_DIR") "/.gemini"))
+    (subpath (string-append (param "HOME_DIR") "/.ionesco"))
     (subpath (string-append (param "HOME_DIR") "/.npm"))
     (subpath (string-append (param "HOME_DIR") "/.cache"))
     (subpath (string-append (param "HOME_DIR") "/.gitconfig"))

--- a/packages/core/src/code_assist/oauth-credential-storage.ts
+++ b/packages/core/src/code_assist/oauth-credential-storage.ts
@@ -12,7 +12,7 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import { promises as fs } from 'node:fs';
 
-const GEMINI_DIR = '.gemini';
+const GEMINI_DIR = '.ionesco';
 const KEYCHAIN_SERVICE_NAME = 'gemini-cli-oauth';
 const MAIN_ACCOUNT_KEY = 'main-account';
 

--- a/packages/core/src/code_assist/oauth2.test.ts
+++ b/packages/core/src/code_assist/oauth2.test.ts
@@ -182,7 +182,7 @@ describe('oauth2', () => {
       // Verify Google Account was cached
       const googleAccountPath = path.join(
         tempHomeDir,
-        '.gemini',
+        '.ionesco',
         'google_accounts.json',
       );
       expect(fs.existsSync(googleAccountPath)).toBe(true);
@@ -290,7 +290,11 @@ describe('oauth2', () => {
 
       it('should attempt to load cached credentials first', async () => {
         const cachedCreds = { refresh_token: 'cached-token' };
-        const credsPath = path.join(tempHomeDir, '.gemini', 'oauth_creds.json');
+        const credsPath = path.join(
+          tempHomeDir,
+          '.ionesco',
+          'oauth_creds.json',
+        );
         await fs.promises.mkdir(path.dirname(credsPath), { recursive: true });
         await fs.promises.writeFile(credsPath, JSON.stringify(cachedCreds));
 
@@ -328,7 +332,11 @@ describe('oauth2', () => {
 
         await getOauthClient(AuthType.CLOUD_SHELL, mockConfig);
 
-        const credsPath = path.join(tempHomeDir, '.gemini', 'oauth_creds.json');
+        const credsPath = path.join(
+          tempHomeDir,
+          '.ionesco',
+          'oauth_creds.json',
+        );
         expect(fs.existsSync(credsPath)).toBe(false);
       });
 
@@ -355,7 +363,7 @@ describe('oauth2', () => {
         const defaultCreds = { refresh_token: 'default-cached-token' };
         const defaultCredsPath = path.join(
           tempHomeDir,
-          '.gemini',
+          '.ionesco',
           'oauth_creds.json',
         );
         await fs.promises.mkdir(path.dirname(defaultCredsPath), {
@@ -463,7 +471,7 @@ describe('oauth2', () => {
         // Verify Google Account was cached
         const googleAccountPath = path.join(
           tempHomeDir,
-          '.gemini',
+          '.ionesco',
           'google_accounts.json',
         );
         const cachedContent = fs.readFileSync(googleAccountPath, 'utf-8');
@@ -493,7 +501,11 @@ describe('oauth2', () => {
 
         // Make it fall through to cached credentials path
         const cachedCreds = { refresh_token: 'cached-token' };
-        const credsPath = path.join(tempHomeDir, '.gemini', 'oauth_creds.json');
+        const credsPath = path.join(
+          tempHomeDir,
+          '.ionesco',
+          'oauth_creds.json',
+        );
         await fs.promises.mkdir(path.dirname(credsPath), { recursive: true });
         await fs.promises.writeFile(credsPath, JSON.stringify(cachedCreds));
 
@@ -524,7 +536,11 @@ describe('oauth2', () => {
 
         // Make it fall through to cached credentials path
         const cachedCreds = { refresh_token: 'cached-token' };
-        const credsPath = path.join(tempHomeDir, '.gemini', 'oauth_creds.json');
+        const credsPath = path.join(
+          tempHomeDir,
+          '.ionesco',
+          'oauth_creds.json',
+        );
         await fs.promises.mkdir(path.dirname(credsPath), { recursive: true });
         await fs.promises.writeFile(credsPath, JSON.stringify(cachedCreds));
 
@@ -916,13 +932,17 @@ describe('oauth2', () => {
     describe('clearCachedCredentialFile', () => {
       it('should clear cached credentials and Google account', async () => {
         const cachedCreds = { refresh_token: 'test-token' };
-        const credsPath = path.join(tempHomeDir, '.gemini', 'oauth_creds.json');
+        const credsPath = path.join(
+          tempHomeDir,
+          '.ionesco',
+          'oauth_creds.json',
+        );
         await fs.promises.mkdir(path.dirname(credsPath), { recursive: true });
         await fs.promises.writeFile(credsPath, JSON.stringify(cachedCreds));
 
         const googleAccountPath = path.join(
           tempHomeDir,
-          '.gemini',
+          '.ionesco',
           'google_accounts.json',
         );
         const accountData = { active: 'test@example.com', old: [] };
@@ -965,7 +985,11 @@ describe('oauth2', () => {
         );
 
         // Pre-populate credentials to make getOauthClient resolve quickly
-        const credsPath = path.join(tempHomeDir, '.gemini', 'oauth_creds.json');
+        const credsPath = path.join(
+          tempHomeDir,
+          '.ionesco',
+          'oauth_creds.json',
+        );
         await fs.promises.mkdir(path.dirname(credsPath), { recursive: true });
         await fs.promises.writeFile(
           credsPath,
@@ -1104,7 +1128,7 @@ describe('oauth2', () => {
       expect(
         OAuthCredentialStorage.saveCredentials as Mock,
       ).toHaveBeenCalledWith(mockTokens);
-      const credsPath = path.join(tempHomeDir, '.gemini', 'oauth_creds.json');
+      const credsPath = path.join(tempHomeDir, '.ionesco', 'oauth_creds.json');
       expect(fs.existsSync(credsPath)).toBe(false);
     });
 
@@ -1120,7 +1144,7 @@ describe('oauth2', () => {
       // Create a dummy unencrypted credential file.
       // If the logic is correct, this file should be ignored.
       const unencryptedCreds = { refresh_token: 'unencrypted-token' };
-      const credsPath = path.join(tempHomeDir, '.gemini', 'oauth_creds.json');
+      const credsPath = path.join(tempHomeDir, '.ionesco', 'oauth_creds.json');
       await fs.promises.mkdir(path.dirname(credsPath), { recursive: true });
       await fs.promises.writeFile(credsPath, JSON.stringify(unencryptedCreds));
 
@@ -1150,7 +1174,7 @@ describe('oauth2', () => {
       );
 
       // Create a dummy unencrypted credential file. It should not be deleted.
-      const credsPath = path.join(tempHomeDir, '.gemini', 'oauth_creds.json');
+      const credsPath = path.join(tempHomeDir, '.ionesco', 'oauth_creds.json');
       await fs.promises.mkdir(path.dirname(credsPath), { recursive: true });
       await fs.promises.writeFile(credsPath, '{}');
 

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -77,7 +77,7 @@ vi.mock('../tools/memoryTool', () => ({
   setGeminiMdFilename: vi.fn(),
   getCurrentGeminiMdFilename: vi.fn(() => 'GEMINI.md'), // Mock the original filename
   DEFAULT_CONTEXT_FILENAME: 'GEMINI.md',
-  GEMINI_CONFIG_DIR: '.gemini',
+  GEMINI_CONFIG_DIR: '.ionesco',
 }));
 
 const mockContentGeneratorFns = {
@@ -130,6 +130,9 @@ const mockProvider = {
   createContentGeneratorConfig: vi.fn(),
   createContentGenerator: vi.fn(),
   createConversationClient: vi.fn(() => mockConversationClient),
+  createToolingSupport: vi.fn(
+    () => new UnsupportedModelToolingSupport('mock-provider'),
+  ),
 };
 
 vi.mock('../providers/modelProviderRegistry.js', () => ({
@@ -192,6 +195,7 @@ vi.mock('../ide/ide-client.js', () => ({
 import { BaseLlmClient } from '../core/baseLlmClient.js';
 import { tokenLimit } from '../core/tokenLimits.js';
 import { uiTelemetryService } from '../telemetry/index.js';
+import { UnsupportedModelToolingSupport } from '../providers/modelToolingSupport.js';
 
 vi.mock('../core/baseLlmClient.js');
 vi.mock('../core/tokenLimits.js', () => ({

--- a/packages/core/src/config/flashFallback.test.ts
+++ b/packages/core/src/config/flashFallback.test.ts
@@ -65,7 +65,7 @@ describe('Flash Model Fallback Configuration', () => {
       expect(config.getModel()).toBe(DEFAULT_GEMINI_FLASH_MODEL);
     });
 
-    it('should fall back to initial model if contentGeneratorConfig is not available', () => {
+    it('should fall back to provider default model if contentGeneratorConfig is not available', () => {
       // Test with fresh config where contentGeneratorConfig might not be set
       const newConfig = new Config({
         sessionId: 'test-session-2',
@@ -75,7 +75,7 @@ describe('Flash Model Fallback Configuration', () => {
         model: 'custom-model',
       });
 
-      expect(newConfig.getModel()).toBe('custom-model');
+      expect(newConfig.getModel()).toBe(DEFAULT_GEMINI_MODEL);
     });
   });
 

--- a/packages/core/src/config/storage.test.ts
+++ b/packages/core/src/config/storage.test.ts
@@ -13,14 +13,15 @@ vi.mock('fs', async (importOriginal) => {
   return {
     ...actual,
     mkdirSync: vi.fn(),
+    cpSync: vi.fn(),
   };
 });
 
-import { Storage } from './storage.js';
+import { Storage, GEMINI_DIR } from './storage.js';
 
 describe('Storage – getGlobalSettingsPath', () => {
   it('returns path to ~/.gemini/settings.json', () => {
-    const expected = path.join(os.homedir(), '.gemini', 'settings.json');
+    const expected = path.join(os.homedir(), GEMINI_DIR, 'settings.json');
     expect(Storage.getGlobalSettingsPath()).toBe(expected);
   });
 });
@@ -30,31 +31,31 @@ describe('Storage – additional helpers', () => {
   const storage = new Storage(projectRoot);
 
   it('getWorkspaceSettingsPath returns project/.gemini/settings.json', () => {
-    const expected = path.join(projectRoot, '.gemini', 'settings.json');
+    const expected = path.join(projectRoot, GEMINI_DIR, 'settings.json');
     expect(storage.getWorkspaceSettingsPath()).toBe(expected);
   });
 
   it('getUserCommandsDir returns ~/.gemini/commands', () => {
-    const expected = path.join(os.homedir(), '.gemini', 'commands');
+    const expected = path.join(os.homedir(), GEMINI_DIR, 'commands');
     expect(Storage.getUserCommandsDir()).toBe(expected);
   });
 
   it('getProjectCommandsDir returns project/.gemini/commands', () => {
-    const expected = path.join(projectRoot, '.gemini', 'commands');
+    const expected = path.join(projectRoot, GEMINI_DIR, 'commands');
     expect(storage.getProjectCommandsDir()).toBe(expected);
   });
 
   it('getMcpOAuthTokensPath returns ~/.gemini/mcp-oauth-tokens.json', () => {
     const expected = path.join(
       os.homedir(),
-      '.gemini',
+      GEMINI_DIR,
       'mcp-oauth-tokens.json',
     );
     expect(Storage.getMcpOAuthTokensPath()).toBe(expected);
   });
 
   it('getGlobalBinDir returns ~/.gemini/tmp/bin', () => {
-    const expected = path.join(os.homedir(), '.gemini', 'tmp', 'bin');
+    const expected = path.join(os.homedir(), GEMINI_DIR, 'tmp', 'bin');
     expect(Storage.getGlobalBinDir()).toBe(expected);
   });
 });

--- a/packages/core/src/core/logger.test.ts
+++ b/packages/core/src/core/logger.test.ts
@@ -28,7 +28,7 @@ import type { Content } from '@google/genai';
 import crypto from 'node:crypto';
 import os from 'node:os';
 
-const GEMINI_DIR_NAME = '.gemini';
+const GEMINI_DIR_NAME = '.ionesco';
 const TMP_DIR_NAME = 'tmp';
 const LOG_FILE_NAME = 'logs.json';
 const CHECKPOINT_FILE_NAME = 'checkpoint.json';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -64,6 +64,7 @@ export * from './services/fileSystemService.js';
 
 // Export provider abstractions
 export * from './providers/types.js';
+export * from './providers/modelToolingSupport.js';
 export { ModelProviderRegistryImpl } from './providers/modelProviderRegistry.js';
 export { GrokProvider } from './providers/grokProvider.js';
 export { logGrokDebug } from './providers/grokDebugLogger.js';

--- a/packages/core/src/mcp/token-storage/file-token-storage.test.ts
+++ b/packages/core/src/mcp/token-storage/file-token-storage.test.ts
@@ -135,7 +135,7 @@ describe('FileTokenStorage', () => {
       await storage.setCredentials(credentials);
 
       expect(mockFs.mkdir).toHaveBeenCalledWith(
-        path.join('/home/test', '.gemini'),
+        path.join('/home/test', '.ionesco'),
         { recursive: true, mode: 0o700 },
       );
       expect(mockFs.writeFile).toHaveBeenCalled();
@@ -201,7 +201,7 @@ describe('FileTokenStorage', () => {
       await storage.deleteCredentials('test-server');
 
       expect(mockFs.unlink).toHaveBeenCalledWith(
-        path.join('/home/test', '.gemini', 'mcp-oauth-tokens-v2.json'),
+        path.join('/home/test', '.ionesco', 'mcp-oauth-tokens-v2.json'),
       );
     });
 
@@ -282,7 +282,7 @@ describe('FileTokenStorage', () => {
       await storage.clearAll();
 
       expect(mockFs.unlink).toHaveBeenCalledWith(
-        path.join('/home/test', '.gemini', 'mcp-oauth-tokens-v2.json'),
+        path.join('/home/test', '.ionesco', 'mcp-oauth-tokens-v2.json'),
       );
     });
 

--- a/packages/core/src/mcp/token-storage/file-token-storage.ts
+++ b/packages/core/src/mcp/token-storage/file-token-storage.ts
@@ -17,7 +17,7 @@ export class FileTokenStorage extends BaseTokenStorage {
 
   constructor(serviceName: string) {
     super(serviceName);
-    const configDir = path.join(os.homedir(), '.gemini');
+    const configDir = path.join(os.homedir(), '.ionesco');
     this.tokenFilePath = path.join(configDir, 'mcp-oauth-tokens-v2.json');
     this.encryptionKey = this.deriveEncryptionKey();
   }

--- a/packages/core/src/providers/googleGenaiProvider.ts
+++ b/packages/core/src/providers/googleGenaiProvider.ts
@@ -4,8 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {
-  AuthType} from '../core/contentGenerator.js';
+import type { AuthType } from '../core/contentGenerator.js';
 import {
   createContentGenerator,
   createContentGeneratorConfig,
@@ -15,6 +14,11 @@ import {
 import { GeminiClient } from '../core/client.js';
 import type { Config } from '../config/config.js';
 import { DEFAULT_GEMINI_MODEL } from '../config/models.js';
+import {
+  type ModelToolingSupport,
+  type ModelToolingSupportDependencies,
+} from './modelToolingSupport.js';
+import { GoogleToolingSupport } from './googleToolingSupport.js';
 import type { ModelProvider } from './types.js';
 
 /**
@@ -52,5 +56,12 @@ export class GoogleGenAIProvider implements ModelProvider {
 
   createConversationClient(config: Config): GeminiClient {
     return new GeminiClient(config);
+  }
+
+  createToolingSupport(
+    config: Config,
+    dependencies: ModelToolingSupportDependencies,
+  ): ModelToolingSupport {
+    return new GoogleToolingSupport(config, dependencies);
   }
 }

--- a/packages/core/src/providers/googleToolingSupport.ts
+++ b/packages/core/src/providers/googleToolingSupport.ts
@@ -1,0 +1,414 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Config } from '../config/config.js';
+import { DEFAULT_GEMINI_FLASH_MODEL } from '../config/models.js';
+import type { ToolResult } from '../tools/tools.js';
+import type { WebSearchToolResult } from '../tools/web-search.js';
+import { ToolErrorType } from '../tools/tool-error.js';
+import { getResponseText } from '../utils/partUtils.js';
+import { getErrorMessage } from '../utils/errors.js';
+import { fetchWithTimeout, isPrivateIp } from '../utils/fetch.js';
+import { summarizeToolOutput } from '../utils/summarizer.js';
+import {
+  ensureCorrectEdit,
+  ensureCorrectFileContent,
+} from '../utils/editCorrector.js';
+import { FixLLMEditWithInstruction } from '../utils/llm-edit-fixer.js';
+import type {
+  EnsureCorrectEditRequest,
+  FixEditWithInstructionRequest,
+  ModelToolingSupport,
+  ModelToolingSupportDependencies,
+  SummarizeTextRequest,
+} from './modelToolingSupport.js';
+import type { CorrectedEditResult } from '../utils/editCorrector.js';
+import type { SearchReplaceEdit } from '../utils/llm-edit-fixer.js';
+import type { GeminiClient } from '../core/client.js';
+import type { BaseLlmClient } from '../core/baseLlmClient.js';
+import { ProxyAgent, setGlobalDispatcher } from 'undici';
+import { convert } from 'html-to-text';
+
+interface GroundingChunkWeb {
+  uri?: string;
+  title?: string;
+}
+
+interface GroundingChunkItem {
+  web?: GroundingChunkWeb;
+}
+
+interface GroundingSupportSegment {
+  startIndex: number;
+  endIndex: number;
+  text?: string;
+}
+
+interface GroundingSupportItem {
+  segment?: GroundingSupportSegment;
+  groundingChunkIndices?: number[];
+  confidenceScores?: number[];
+}
+
+const URL_FETCH_TIMEOUT_MS = 10000;
+const MAX_CONTENT_LENGTH = 100000;
+
+function extractUrls(text: string): string[] {
+  const urlRegex = /(https?:\/\/[^\s]+)/g;
+  return text.match(urlRegex) ?? [];
+}
+
+export class GoogleToolingSupport implements ModelToolingSupport {
+  constructor(
+    private readonly config: Config,
+    private readonly dependencies: ModelToolingSupportDependencies,
+  ) {
+    const proxy = this.config.getProxy();
+    if (proxy) {
+      setGlobalDispatcher(new ProxyAgent(proxy as string));
+    }
+  }
+
+  async performWebSearch(
+    query: string,
+    abortSignal: AbortSignal,
+  ): Promise<WebSearchToolResult> {
+    const geminiClient = this.getConversationClient();
+
+    try {
+      const response = await geminiClient.generateContent(
+        [{ role: 'user', parts: [{ text: query }] }],
+        { tools: [{ googleSearch: {} }] },
+        abortSignal,
+        DEFAULT_GEMINI_FLASH_MODEL,
+      );
+
+      const responseText = getResponseText(response);
+      const groundingMetadata = response.candidates?.[0]?.groundingMetadata;
+      const sources = groundingMetadata?.groundingChunks as
+        | GroundingChunkItem[]
+        | undefined;
+      const groundingSupports = groundingMetadata?.groundingSupports as
+        | GroundingSupportItem[]
+        | undefined;
+
+      if (!responseText || !responseText.trim()) {
+        return {
+          llmContent: `No search results or information found for query: "${query}"`,
+          returnDisplay: 'No information found.',
+        };
+      }
+
+      let modifiedResponseText = responseText;
+      const sourceListFormatted: string[] = [];
+
+      if (sources && sources.length > 0) {
+        sources.forEach((source: GroundingChunkItem, index: number) => {
+          const title = source.web?.title || 'Untitled';
+          const uri = source.web?.uri || 'No URI';
+          sourceListFormatted.push(`[${index + 1}] ${title} (${uri})`);
+        });
+
+        if (groundingSupports && groundingSupports.length > 0) {
+          const insertions: Array<{ index: number; marker: string }> = [];
+          groundingSupports.forEach((support: GroundingSupportItem) => {
+            if (support.segment && support.groundingChunkIndices) {
+              const citationMarker = support.groundingChunkIndices
+                .map((chunkIndex: number) => `[${chunkIndex + 1}]`)
+                .join('');
+              insertions.push({
+                index: support.segment.endIndex,
+                marker: citationMarker,
+              });
+            }
+          });
+
+          insertions.sort((a, b) => b.index - a.index);
+          const encoder = new TextEncoder();
+          const originalBytes = encoder.encode(modifiedResponseText);
+          const parts: Uint8Array[] = [];
+          let lastIndex = originalBytes.length;
+          for (const insertion of insertions) {
+            const index = Math.min(insertion.index, lastIndex);
+            parts.unshift(originalBytes.subarray(index, lastIndex));
+            parts.unshift(encoder.encode(insertion.marker));
+            lastIndex = index;
+          }
+          parts.unshift(originalBytes.subarray(0, lastIndex));
+
+          const totalLength = parts.reduce((sum, p) => sum + p.length, 0);
+          const merged = new Uint8Array(totalLength);
+          let offset = 0;
+          for (const part of parts) {
+            merged.set(part, offset);
+            offset += part.length;
+          }
+          modifiedResponseText = new TextDecoder().decode(merged);
+        }
+
+        if (sourceListFormatted.length > 0) {
+          modifiedResponseText +=
+            '\n\nSources:\n' + sourceListFormatted.join('\n');
+        }
+      }
+
+      return {
+        llmContent: `Web search results for "${query}":\n\n${modifiedResponseText}`,
+        returnDisplay: `Search results for "${query}" returned.`,
+        sources,
+      };
+    } catch (error: unknown) {
+      const message = `Error during web search for query "${query}": ${getErrorMessage(error)}`;
+      console.error(message, error);
+      return {
+        llmContent: `Error: ${message}`,
+        returnDisplay: `Error performing web search.`,
+        error: {
+          message,
+          type: ToolErrorType.WEB_SEARCH_FAILED,
+        },
+      };
+    }
+  }
+
+  async performWebFetch(
+    prompt: string,
+    abortSignal: AbortSignal,
+  ): Promise<ToolResult> {
+    const urls = extractUrls(prompt);
+    if (urls.length === 0) {
+      return {
+        llmContent:
+          'No valid URLs detected in the prompt. Please include at least one http:// or https:// URL.',
+        returnDisplay: 'No URLs provided.',
+        error: {
+          message: 'No URLs provided.',
+          type: ToolErrorType.WEB_FETCH_PROCESSING_ERROR,
+        },
+      };
+    }
+
+    const firstUrl = urls[0];
+    if (isPrivateIp(firstUrl)) {
+      return this.executeFetchFallback(firstUrl, prompt, abortSignal);
+    }
+
+    const geminiClient = this.getConversationClient();
+
+    try {
+      const response = await geminiClient.generateContent(
+        [{ role: 'user', parts: [{ text: prompt }] }],
+        { tools: [{ urlContext: {} }] },
+        abortSignal,
+        DEFAULT_GEMINI_FLASH_MODEL,
+      );
+
+      let responseText = getResponseText(response) || '';
+      const candidate = response.candidates?.[0];
+      const urlMeta = candidate?.urlContextMetadata;
+      const groundingMetadata = candidate?.groundingMetadata;
+      const sources = groundingMetadata?.groundingChunks as
+        | GroundingChunkItem[]
+        | undefined;
+      const groundingSupports = groundingMetadata?.groundingSupports as
+        | GroundingSupportItem[]
+        | undefined;
+
+      let processingError = false;
+      if (urlMeta?.urlMetadata && urlMeta.urlMetadata.length > 0) {
+        const statuses = urlMeta.urlMetadata.map((m) => m.urlRetrievalStatus);
+        if (statuses.every((s) => s !== 'URL_RETRIEVAL_STATUS_SUCCESS')) {
+          processingError = true;
+        }
+      } else if (!responseText.trim() && !sources?.length) {
+        processingError = true;
+      }
+
+      if (
+        !processingError &&
+        !responseText.trim() &&
+        (!sources || sources.length === 0)
+      ) {
+        processingError = true;
+      }
+
+      if (processingError) {
+        return this.executeFetchFallback(firstUrl, prompt, abortSignal);
+      }
+
+      const formattedSources: string[] = [];
+      if (sources && sources.length > 0) {
+        sources.forEach((source: GroundingChunkItem, index: number) => {
+          const title = source.web?.title || 'Untitled';
+          const uri = source.web?.uri || 'Unknown URI';
+          formattedSources.push(`[${index + 1}] ${title} (${uri})`);
+        });
+
+        if (groundingSupports && groundingSupports.length > 0) {
+          const insertions: Array<{ index: number; marker: string }> = [];
+          groundingSupports.forEach((support: GroundingSupportItem) => {
+            if (support.segment && support.groundingChunkIndices) {
+              const marker = support.groundingChunkIndices
+                .map((chunkIndex) => `[${chunkIndex + 1}]`)
+                .join('');
+              insertions.push({ index: support.segment.endIndex, marker });
+            }
+          });
+
+          insertions.sort((a, b) => b.index - a.index);
+          const characters = responseText.split('');
+          insertions.forEach((insertion) => {
+            characters.splice(insertion.index, 0, insertion.marker);
+          });
+          responseText = characters.join('');
+        }
+
+        if (formattedSources.length > 0) {
+          responseText += `\n\nSources:\n${formattedSources.join('\n')}`;
+        }
+      }
+
+      return {
+        llmContent: responseText,
+        returnDisplay: `Content processed from prompt.`,
+      };
+    } catch (error: unknown) {
+      const message = `Error processing web content for prompt "${prompt.substring(
+        0,
+        50,
+      )}...": ${getErrorMessage(error)}`;
+      console.error(message, error);
+      return {
+        llmContent: `Error: ${message}`,
+        returnDisplay: `Error: ${message}`,
+        error: {
+          message,
+          type: ToolErrorType.WEB_FETCH_PROCESSING_ERROR,
+        },
+      };
+    }
+  }
+
+  async ensureCorrectEdit(
+    request: EnsureCorrectEditRequest,
+  ): Promise<CorrectedEditResult> {
+    const { filePath, currentContent, originalParams, abortSignal } = request;
+    return ensureCorrectEdit(
+      filePath,
+      currentContent,
+      originalParams,
+      this.getConversationClient(),
+      this.getBaseLlmClient(),
+      abortSignal,
+    );
+  }
+
+  async ensureCorrectFileContent(
+    content: string,
+    abortSignal: AbortSignal,
+  ): Promise<string> {
+    return ensureCorrectFileContent(
+      content,
+      this.getBaseLlmClient(),
+      abortSignal,
+    );
+  }
+
+  async fixEditWithInstruction(
+    request: FixEditWithInstructionRequest,
+  ): Promise<SearchReplaceEdit> {
+    return FixLLMEditWithInstruction(
+      request.instruction,
+      request.oldString,
+      request.newString,
+      request.error,
+      request.currentContent,
+      this.getBaseLlmClient(),
+      request.abortSignal,
+    );
+  }
+
+  async summarizeText(request: SummarizeTextRequest): Promise<string> {
+    return summarizeToolOutput(
+      request.text,
+      this.getConversationClient(),
+      request.abortSignal,
+      request.maxOutputTokens ?? 2000,
+    );
+  }
+
+  private async executeFetchFallback(
+    url: string,
+    originalPrompt: string,
+    abortSignal: AbortSignal,
+  ): Promise<ToolResult> {
+    let targetUrl = url;
+    if (targetUrl.includes('github.com') && targetUrl.includes('/blob/')) {
+      targetUrl = targetUrl
+        .replace('github.com', 'raw.githubusercontent.com')
+        .replace('/blob/', '/');
+    }
+
+    try {
+      const response = await fetchWithTimeout(targetUrl, URL_FETCH_TIMEOUT_MS);
+      if (!response.ok) {
+        throw new Error(
+          `Request failed with status code ${response.status} ${response.statusText}`,
+        );
+      }
+      const html = await response.text();
+      const textContent = convert(html, {
+        wordwrap: false,
+        selectors: [
+          { selector: 'a', options: { ignoreHref: true } },
+          { selector: 'img', format: 'skip' },
+        ],
+      }).substring(0, MAX_CONTENT_LENGTH);
+
+      const prompt = `The user requested the following: "${originalPrompt}".
+
+I was unable to access the URL directly using urlContext. Instead, I have fetched the raw content of the page. Please use the following content to answer the request. Do not attempt to access the URL again.
+
+---
+${textContent}
+---
+`;
+
+      const geminiClient = this.getConversationClient();
+      const result = await geminiClient.generateContent(
+        [{ role: 'user', parts: [{ text: prompt }] }],
+        {},
+        abortSignal,
+        DEFAULT_GEMINI_FLASH_MODEL,
+      );
+      const resultText = getResponseText(result) || '';
+      return {
+        llmContent: resultText,
+        returnDisplay: `Content for ${targetUrl} processed using fallback fetch.`,
+      };
+    } catch (error: unknown) {
+      const message = `Error during fallback fetch for ${targetUrl}: ${getErrorMessage(error)}`;
+      return {
+        llmContent: `Error: ${message}`,
+        returnDisplay: `Error: ${message}`,
+        error: {
+          message,
+          type: ToolErrorType.WEB_FETCH_FALLBACK_FAILED,
+        },
+      };
+    }
+  }
+
+  private getConversationClient(): GeminiClient {
+    return (
+      this.dependencies.conversationClient ?? this.config.getGeminiClient()
+    );
+  }
+
+  private getBaseLlmClient(): BaseLlmClient {
+    return this.dependencies.baseLlmClient ?? this.config.getBaseLlmClient();
+  }
+}

--- a/packages/core/src/providers/grokToolingSupport.test.ts
+++ b/packages/core/src/providers/grokToolingSupport.test.ts
@@ -1,0 +1,105 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+
+import { GrokToolingSupport } from './grokToolingSupport.js';
+import type { GrokSidecarClient } from './grokSidecarClient.js';
+
+function createSupport(overrides: Partial<GrokSidecarClient> = {}) {
+  const sidecar = {
+    ensureInitialised: vi.fn().mockResolvedValue(undefined),
+    webSearch: vi.fn().mockResolvedValue({
+      llmContent: 'search-response',
+      returnDisplay: 'display',
+      sources: ['https://example.com'],
+    }),
+    webFetch: vi.fn().mockResolvedValue({
+      llmContent: 'fetch-response',
+      returnDisplay: 'display',
+    }),
+    ensureCorrectEdit: vi.fn().mockResolvedValue({
+      params: {
+        file_path: 'file',
+        old_string: 'foo',
+        new_string: 'bar',
+      },
+      occurrences: 2,
+    }),
+    ensureCorrectFileContent: vi.fn().mockResolvedValue({
+      content: 'clean-content',
+    }),
+    fixEditWithInstruction: vi.fn().mockResolvedValue({
+      search: 'foo',
+      replace: 'bar',
+      explanation: 'done',
+    }),
+    summarizeText: vi.fn().mockResolvedValue({ summary: 'summary' }),
+    ...overrides,
+  } as unknown as GrokSidecarClient;
+
+  const support = new GrokToolingSupport(sidecar, {
+    apiKey: 'test-key',
+    model: 'grok-4',
+  });
+
+  return { support, sidecar };
+}
+
+describe('GrokToolingSupport', () => {
+  let abortSignal: AbortSignal;
+
+  beforeEach(() => {
+    abortSignal = new AbortController().signal;
+  });
+
+  it('performs web search via sidecar', async () => {
+    const { support, sidecar } = createSupport();
+    const result = await support.performWebSearch('query', abortSignal);
+
+    expect(sidecar.ensureInitialised).toHaveBeenCalledOnce();
+    expect(sidecar.webSearch).toHaveBeenCalledWith(
+      'query',
+      expect.objectContaining({ mode: 'on' }),
+      abortSignal,
+    );
+    expect(result.llmContent).toBe('search-response');
+    expect(result.returnDisplay).toBe('display');
+    expect(result.sources).toEqual(['https://example.com']);
+  });
+
+  it('ensures correct edit uses sidecar response', async () => {
+    const { support } = createSupport();
+    const result = await support.ensureCorrectEdit({
+      filePath: 'file',
+      currentContent: 'foo baz foo',
+      originalParams: {
+        file_path: 'file',
+        old_string: 'baz',
+        new_string: 'qux',
+      },
+      abortSignal,
+    });
+
+    expect(result.params.old_string).toBe('foo');
+    expect(result.params.new_string).toBe('bar');
+    expect(result.occurrences).toBe(2);
+  });
+
+  it('falls back to original text when summarise payload empty', async () => {
+    const { support, sidecar } = createSupport({
+      summarizeText: vi.fn().mockResolvedValue({ summary: '' }),
+    });
+
+    const text = await support.summarizeText({
+      text: 'fallback text',
+      abortSignal,
+    });
+
+    expect(sidecar.ensureInitialised).toHaveBeenCalledOnce();
+    expect(text).toBe('fallback text');
+  });
+});

--- a/packages/core/src/providers/grokToolingSupport.ts
+++ b/packages/core/src/providers/grokToolingSupport.ts
@@ -1,0 +1,292 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ToolResult } from '../tools/tools.js';
+import type { WebSearchToolResult } from '../tools/web-search.js';
+import type {
+  EnsureCorrectEditRequest,
+  FixEditWithInstructionRequest,
+  ModelToolingSupport,
+  SummarizeTextRequest,
+} from './modelToolingSupport.js';
+import type { CorrectedEditResult } from '../utils/editCorrector.js';
+import type { SearchReplaceEdit } from '../utils/llm-edit-fixer.js';
+import type {
+  GrokEnsureCorrectEditPayload,
+  GrokEnsureCorrectFileContentPayload,
+  GrokFixEditWithInstructionPayload,
+  GrokSummarizeTextPayload,
+  GrokToolResultPayload,
+} from './grokSidecarClient.js';
+import type { GrokSidecarClient } from './grokSidecarClient.js';
+
+interface GrokToolingSupportOptions {
+  apiKey: string;
+  model?: string;
+  pythonPath?: string;
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  if (!needle) {
+    return 0;
+  }
+  return haystack.split(needle).length - 1;
+}
+
+export class GrokToolingSupport implements ModelToolingSupport {
+  private initialisationPromise?: Promise<void>;
+
+  constructor(
+    private readonly sidecar: GrokSidecarClient,
+    private readonly options: GrokToolingSupportOptions,
+  ) {}
+
+  async performWebSearch(
+    query: string,
+    abortSignal: AbortSignal,
+  ): Promise<WebSearchToolResult> {
+    await this.ensureReady();
+    const payload: GrokToolResultPayload | undefined =
+      await this.sidecar.webSearch(query, { mode: 'on' }, abortSignal);
+    const fallback = {
+      fallbackContent: `Unable to search for "${query}".`,
+      fallbackDisplay: 'Web search failed.',
+    };
+    return this.toWebToolResult(payload, fallback);
+  }
+
+  async performWebFetch(
+    prompt: string,
+    abortSignal: AbortSignal,
+  ): Promise<ToolResult> {
+    await this.ensureReady();
+    const payload: GrokToolResultPayload | undefined =
+      await this.sidecar.webFetch(prompt, {}, abortSignal);
+    const fallback = {
+      fallbackContent:
+        'Web fetch is unavailable for the Grok provider. Please try again later.',
+      fallbackDisplay: 'Unable to fetch external content.',
+    };
+    return this.toToolResult(payload, fallback);
+  }
+
+  async ensureCorrectEdit(
+    request: EnsureCorrectEditRequest,
+  ): Promise<CorrectedEditResult> {
+    await this.ensureReady();
+    const response: GrokEnsureCorrectEditPayload | undefined =
+      await this.sidecar.ensureCorrectEdit(
+        {
+          filePath: request.filePath,
+          currentContent: request.currentContent,
+          originalParams: request.originalParams,
+        },
+        request.abortSignal,
+      );
+
+    const occurrences = this.resolveOccurrences(
+      request.currentContent,
+      request.originalParams.old_string,
+      response,
+    );
+    const params = this.resolveParams(response, request.originalParams);
+    return { params, occurrences };
+  }
+
+  async ensureCorrectFileContent(
+    content: string,
+    abortSignal: AbortSignal,
+  ): Promise<string> {
+    await this.ensureReady();
+    const response: GrokEnsureCorrectFileContentPayload | undefined =
+      await this.sidecar.ensureCorrectFileContent({ content }, abortSignal);
+    const cleaned = response?.content;
+    if (typeof cleaned === 'string' && cleaned.length > 0) {
+      return cleaned;
+    }
+    return content;
+  }
+
+  async fixEditWithInstruction(
+    request: FixEditWithInstructionRequest,
+  ): Promise<SearchReplaceEdit> {
+    await this.ensureReady();
+    const response: GrokFixEditWithInstructionPayload | undefined =
+      await this.sidecar.fixEditWithInstruction(
+        {
+          instruction: request.instruction,
+          oldString: request.oldString,
+          newString: request.newString,
+          error: request.error,
+          currentContent: request.currentContent,
+        },
+        request.abortSignal,
+      );
+
+    return this.toSearchReplaceEdit(response, request);
+  }
+
+  async summarizeText(request: SummarizeTextRequest): Promise<string> {
+    await this.ensureReady();
+    const response: GrokSummarizeTextPayload | undefined =
+      await this.sidecar.summarizeText(
+        {
+          text: request.text,
+          max_output_tokens: request.maxOutputTokens,
+        },
+        request.abortSignal,
+      );
+
+    const summary = response?.summary;
+    if (typeof summary === 'string' && summary.trim()) {
+      return summary;
+    }
+    return request.text;
+  }
+
+  // ------------------------------------------------------------------
+  // Helpers
+  // ------------------------------------------------------------------
+  private async ensureReady(): Promise<void> {
+    if (this.initialisationPromise) {
+      await this.initialisationPromise;
+      return;
+    }
+
+    if (!this.options.apiKey) {
+      throw new Error(
+        'GROK_API_KEY is required to use the Grok model provider tooling support.',
+      );
+    }
+
+    const initPromise = this.sidecar
+      .ensureInitialised({
+        apiKey: this.options.apiKey,
+        api_key: this.options.apiKey,
+        model: this.options.model,
+        pythonPath: this.options.pythonPath,
+      })
+      .catch((error) => {
+        this.initialisationPromise = undefined;
+        throw error;
+      });
+
+    this.initialisationPromise = initPromise;
+    await initPromise;
+  }
+
+  private toWebToolResult(
+    payload: GrokToolResultPayload | undefined,
+    fallback: { fallbackContent: string; fallbackDisplay: string },
+  ): WebSearchToolResult {
+    const base = this.toToolResult(payload, fallback);
+    if (payload?.sources !== undefined) {
+      (base as WebSearchToolResult).sources = payload.sources;
+    }
+    return base as WebSearchToolResult;
+  }
+
+  private toToolResult(
+    payload: GrokToolResultPayload | undefined,
+    fallback: { fallbackContent: string; fallbackDisplay: string },
+  ): ToolResult {
+    const llmContent = this.pickString(
+      payload?.llmContent,
+      fallback.fallbackContent,
+    );
+    const returnDisplay = this.pickString(
+      payload?.returnDisplay,
+      fallback.fallbackDisplay,
+    );
+
+    const result: ToolResult = {
+      llmContent,
+      returnDisplay,
+    };
+
+    const error = this.toToolError(payload?.error);
+    if (error) {
+      result.error = error;
+    }
+
+    return result;
+  }
+
+  private toToolError(value: unknown): ToolResult['error'] | undefined {
+    if (!value) {
+      return undefined;
+    }
+
+    if (typeof value === 'string') {
+      return { message: value };
+    }
+
+    if (typeof value === 'object') {
+      const message = (value as { message?: unknown }).message;
+      if (typeof message === 'string') {
+        return { message };
+      }
+    }
+
+    return { message: String(value) };
+  }
+
+  private resolveOccurrences(
+    currentContent: string,
+    originalOldString: string,
+    response?: GrokEnsureCorrectEditPayload,
+  ): number {
+    if (response && typeof response.occurrences === 'number') {
+      return response.occurrences;
+    }
+    return countOccurrences(currentContent, originalOldString);
+  }
+
+  private resolveParams(
+    response: GrokEnsureCorrectEditPayload | undefined,
+    original: CorrectedEditResult['params'],
+  ): CorrectedEditResult['params'] {
+    const params = response?.params;
+    if (
+      params &&
+      typeof params === 'object' &&
+      typeof (params as { old_string?: unknown }).old_string === 'string' &&
+      typeof (params as { new_string?: unknown }).new_string === 'string'
+    ) {
+      return {
+        ...original,
+        ...(params as Record<string, unknown>),
+      } as CorrectedEditResult['params'];
+    }
+    return original;
+  }
+
+  private toSearchReplaceEdit(
+    response: GrokFixEditWithInstructionPayload | undefined,
+    fallback: FixEditWithInstructionRequest,
+  ): SearchReplaceEdit {
+    const search = this.pickString(response?.search, fallback.oldString);
+    const replace = this.pickString(response?.replace, fallback.newString);
+    const explanation = this.pickString(
+      response?.explanation,
+      'Edit parameters adjusted by Grok tooling support.',
+    );
+
+    return {
+      search,
+      replace,
+      noChangesRequired: Boolean(response?.noChangesRequired),
+      explanation,
+    };
+  }
+
+  private pickString(value: unknown, fallback: string): string {
+    if (typeof value === 'string' && value.trim()) {
+      return value;
+    }
+    return fallback;
+  }
+}

--- a/packages/core/src/providers/modelToolingSupport.ts
+++ b/packages/core/src/providers/modelToolingSupport.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ToolResult } from '../tools/tools.js';
+import type { WebSearchToolResult } from '../tools/web-search.js';
+import type { EditToolParams } from '../tools/edit.js';
+import type { CorrectedEditResult } from '../utils/editCorrector.js';
+import type { SearchReplaceEdit } from '../utils/llm-edit-fixer.js';
+import type { GeminiClient } from '../core/client.js';
+import type { BaseLlmClient } from '../core/baseLlmClient.js';
+import type { ContentGenerator } from '../core/contentGenerator.js';
+
+export interface SummarizeTextRequest {
+  text: string;
+  abortSignal: AbortSignal;
+  maxOutputTokens?: number;
+}
+
+export interface EnsureCorrectEditRequest {
+  filePath: string;
+  currentContent: string;
+  originalParams: EditToolParams;
+  abortSignal: AbortSignal;
+}
+
+export interface FixEditWithInstructionRequest {
+  instruction: string;
+  oldString: string;
+  newString: string;
+  error: string;
+  currentContent: string;
+  abortSignal: AbortSignal;
+}
+
+export interface ModelToolingSupportDependencies {
+  conversationClient: GeminiClient;
+  contentGenerator?: ContentGenerator;
+  baseLlmClient?: BaseLlmClient;
+}
+
+export interface ModelToolingSupport {
+  performWebSearch(
+    query: string,
+    abortSignal: AbortSignal,
+  ): Promise<WebSearchToolResult>;
+
+  performWebFetch(
+    prompt: string,
+    abortSignal: AbortSignal,
+  ): Promise<ToolResult>;
+
+  ensureCorrectEdit(
+    request: EnsureCorrectEditRequest,
+  ): Promise<CorrectedEditResult>;
+
+  ensureCorrectFileContent(
+    content: string,
+    abortSignal: AbortSignal,
+  ): Promise<string>;
+
+  fixEditWithInstruction(
+    request: FixEditWithInstructionRequest,
+  ): Promise<SearchReplaceEdit>;
+
+  summarizeText(request: SummarizeTextRequest): Promise<string>;
+}
+
+export class UnsupportedModelToolingSupport implements ModelToolingSupport {
+  constructor(private readonly providerId: string) {}
+
+  private notSupported(feature: string): Error {
+    return new Error(
+      `Model provider ${this.providerId} does not implement tooling feature: ${feature}`,
+    );
+  }
+
+  performWebSearch(): Promise<WebSearchToolResult> {
+    return Promise.reject(this.notSupported('performWebSearch'));
+  }
+
+  performWebFetch(): Promise<ToolResult> {
+    return Promise.reject(this.notSupported('performWebFetch'));
+  }
+
+  ensureCorrectEdit(): Promise<CorrectedEditResult> {
+    return Promise.reject(this.notSupported('ensureCorrectEdit'));
+  }
+
+  ensureCorrectFileContent(): Promise<string> {
+    return Promise.reject(this.notSupported('ensureCorrectFileContent'));
+  }
+
+  fixEditWithInstruction(): Promise<SearchReplaceEdit> {
+    return Promise.reject(this.notSupported('fixEditWithInstruction'));
+  }
+
+  summarizeText(): Promise<string> {
+    return Promise.reject(this.notSupported('summarizeText'));
+  }
+}

--- a/packages/core/src/providers/types.ts
+++ b/packages/core/src/providers/types.ts
@@ -5,13 +5,16 @@
  */
 
 import type { Config } from '../config/config.js';
-import type {
-  AuthType} from '../core/contentGenerator.js';
+import type { AuthType } from '../core/contentGenerator.js';
 import {
   type ContentGenerator,
   type ContentGeneratorConfig,
 } from '../core/contentGenerator.js';
 import type { GeminiClient } from '../core/client.js';
+import type {
+  ModelToolingSupport,
+  ModelToolingSupportDependencies,
+} from './modelToolingSupport.js';
 
 export interface ModelProvider {
   /** Unique identifier for the provider (e.g., google-genai). */
@@ -45,6 +48,14 @@ export interface ModelProvider {
    * Instantiates a conversation client bound to the supplied config.
    */
   createConversationClient(config: Config): GeminiClient;
+
+  /**
+   * Provides access to model-specific tooling helpers used by CLI tools.
+   */
+  createToolingSupport(
+    config: Config,
+    dependencies: ModelToolingSupportDependencies,
+  ): ModelToolingSupport;
 }
 
 export interface ProviderRegistry {

--- a/packages/core/src/tools/memoryTool.test.ts
+++ b/packages/core/src/tools/memoryTool.test.ts
@@ -12,6 +12,7 @@ import {
   getCurrentGeminiMdFilename,
   getAllGeminiMdFilenames,
   DEFAULT_CONTEXT_FILENAME,
+  GEMINI_CONFIG_DIR,
 } from './memoryTool.js';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
@@ -31,6 +32,8 @@ vi.mock(import('node:fs/promises'), async (importOriginal) => {
 
 vi.mock('fs', () => ({
   mkdirSync: vi.fn(),
+  cpSync: vi.fn(),
+  existsSync: vi.fn().mockReturnValue(false),
 }));
 
 vi.mock('os');
@@ -105,7 +108,7 @@ describe('MemoryTool', () => {
     beforeEach(() => {
       testFilePath = path.join(
         os.homedir(),
-        '.gemini',
+        GEMINI_CONFIG_DIR,
         DEFAULT_CONTEXT_FILENAME,
       );
     });
@@ -237,7 +240,7 @@ describe('MemoryTool', () => {
       // Use getCurrentGeminiMdFilename for the default expectation before any setGeminiMdFilename calls in a test
       const expectedFilePath = path.join(
         os.homedir(),
-        '.gemini',
+        GEMINI_CONFIG_DIR,
         getCurrentGeminiMdFilename(), // This will be DEFAULT_CONTEXT_FILENAME unless changed by a test
       );
 
@@ -317,9 +320,11 @@ describe('MemoryTool', () => {
       expect(result).not.toBe(false);
 
       if (result && result.type === 'edit') {
-        const expectedPath = path.join('~', '.gemini', 'GEMINI.md');
+        const expectedPath = path.join('~', GEMINI_CONFIG_DIR, 'GEMINI.md');
         expect(result.title).toBe(`Confirm Memory Save: ${expectedPath}`);
-        expect(result.fileName).toContain(path.join('mock', 'home', '.gemini'));
+        expect(result.fileName).toContain(
+          path.join('mock', 'home', GEMINI_CONFIG_DIR),
+        );
         expect(result.fileName).toContain('GEMINI.md');
         expect(result.fileDiff).toContain('Index: GEMINI.md');
         expect(result.fileDiff).toContain('+## Gemini Added Memories');
@@ -334,7 +339,7 @@ describe('MemoryTool', () => {
       const params = { fact: 'Test fact' };
       const memoryFilePath = path.join(
         os.homedir(),
-        '.gemini',
+        GEMINI_CONFIG_DIR,
         getCurrentGeminiMdFilename(),
       );
 
@@ -352,7 +357,7 @@ describe('MemoryTool', () => {
       const params = { fact: 'Test fact' };
       const memoryFilePath = path.join(
         os.homedir(),
-        '.gemini',
+        GEMINI_CONFIG_DIR,
         getCurrentGeminiMdFilename(),
       );
 
@@ -378,7 +383,7 @@ describe('MemoryTool', () => {
       const params = { fact: 'Test fact' };
       const memoryFilePath = path.join(
         os.homedir(),
-        '.gemini',
+        GEMINI_CONFIG_DIR,
         getCurrentGeminiMdFilename(),
       );
 
@@ -415,7 +420,7 @@ describe('MemoryTool', () => {
       expect(result).not.toBe(false);
 
       if (result && result.type === 'edit') {
-        const expectedPath = path.join('~', '.gemini', 'GEMINI.md');
+        const expectedPath = path.join('~', GEMINI_CONFIG_DIR, 'GEMINI.md');
         expect(result.title).toBe(`Confirm Memory Save: ${expectedPath}`);
         expect(result.fileDiff).toContain('Index: GEMINI.md');
         expect(result.fileDiff).toContain('+- New fact');

--- a/packages/core/src/tools/memoryTool.ts
+++ b/packages/core/src/tools/memoryTool.ts
@@ -60,7 +60,7 @@ Do NOT use this tool:
 - \`fact\` (string, required): The specific fact or piece of information to remember. This should be a clear, self-contained statement. For example, if the user says "My favorite color is blue", the fact would be "My favorite color is blue".
 `;
 
-export const GEMINI_CONFIG_DIR = '.gemini';
+export const GEMINI_CONFIG_DIR = '.ionesco';
 export const DEFAULT_CONTEXT_FILENAME = 'GEMINI.md';
 export const MEMORY_SECTION_HEADER = '## Gemini Added Memories';
 

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -23,7 +23,6 @@ import {
   Kind,
 } from './tools.js';
 import { getErrorMessage } from '../utils/errors.js';
-import { summarizeToolOutput } from '../utils/summarizer.js';
 import type {
   ShellExecutionConfig,
   ShellOutputEvent,
@@ -274,12 +273,12 @@ export class ShellToolInvocation extends BaseToolInvocation<
           }
         : {};
       if (summarizeConfig && summarizeConfig[ShellTool.Name]) {
-        const summary = await summarizeToolOutput(
-          llmContent,
-          this.config.getGeminiClient(),
-          signal,
-          summarizeConfig[ShellTool.Name].tokenBudget,
-        );
+        const tokenBudget = summarizeConfig[ShellTool.Name].tokenBudget;
+        const summary = await this.config.getToolingSupport().summarizeText({
+          text: llmContent,
+          abortSignal: signal,
+          maxOutputTokens: tokenBudget,
+        });
         return {
           llmContent: summary,
           returnDisplay: returnDisplayMessage,

--- a/packages/core/src/tools/smart-edit.test.ts
+++ b/packages/core/src/tools/smart-edit.test.ts
@@ -18,10 +18,6 @@ vi.mock('../ide/ide-client.js', () => ({
   },
 }));
 
-vi.mock('../utils/llm-edit-fixer.js', () => ({
-  FixLLMEditWithInstruction: mockFixLLMEditWithInstruction,
-}));
-
 vi.mock('../core/client.js', () => ({
   GeminiClient: vi.fn().mockImplementation(() => ({
     generateJson: mockGenerateJson,
@@ -65,6 +61,14 @@ describe('SmartEditTool', () => {
   let mockConfig: Config;
   let geminiClient: any;
   let baseLlmClient: BaseLlmClient;
+  let mockToolingSupport: {
+    ensureCorrectEdit: ReturnType<typeof vi.fn>;
+    ensureCorrectFileContent: ReturnType<typeof vi.fn>;
+    performWebSearch: ReturnType<typeof vi.fn>;
+    performWebFetch: ReturnType<typeof vi.fn>;
+    fixEditWithInstruction: ReturnType<typeof mockFixLLMEditWithInstruction>;
+    summarizeText: ReturnType<typeof vi.fn>;
+  };
 
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -79,6 +83,15 @@ describe('SmartEditTool', () => {
     baseLlmClient = {
       generateJson: mockGenerateJson,
     } as unknown as BaseLlmClient;
+
+    mockToolingSupport = {
+      ensureCorrectEdit: vi.fn(),
+      ensureCorrectFileContent: vi.fn(),
+      performWebSearch: vi.fn(),
+      performWebFetch: vi.fn(),
+      fixEditWithInstruction: mockFixLLMEditWithInstruction,
+      summarizeText: vi.fn(),
+    };
 
     mockConfig = {
       getGeminiClient: vi.fn().mockReturnValue(geminiClient),
@@ -105,7 +118,10 @@ describe('SmartEditTool', () => {
       getGeminiMdFileCount: () => 0,
       setGeminiMdFileCount: vi.fn(),
       getToolRegistry: () => ({}) as any,
+      getToolingSupport: vi.fn(),
     } as unknown as Config;
+
+    (mockConfig.getToolingSupport as Mock).mockReturnValue(mockToolingSupport);
 
     (mockConfig.getApprovalMode as Mock).mockClear();
     (mockConfig.getApprovalMode as Mock).mockReturnValue(ApprovalMode.DEFAULT);

--- a/packages/core/src/tools/web-search.test.ts
+++ b/packages/core/src/tools/web-search.test.ts
@@ -4,30 +4,31 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Mock } from 'vitest';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { WebSearchToolParams } from './web-search.js';
 import { WebSearchTool } from './web-search.js';
 import type { Config } from '../config/config.js';
-import { GeminiClient } from '../core/client.js';
 import { ToolErrorType } from './tool-error.js';
-
-// Mock GeminiClient and Config constructor
-vi.mock('../core/client.js');
-vi.mock('../config/config.js');
 
 describe('WebSearchTool', () => {
   const abortSignal = new AbortController().signal;
-  let mockGeminiClient: GeminiClient;
   let tool: WebSearchTool;
+  let mockConfig: Config;
+  let mockToolingSupport: {
+    performWebSearch: ReturnType<typeof vi.fn>;
+  };
 
   beforeEach(() => {
-    const mockConfigInstance = {
-      getGeminiClient: () => mockGeminiClient,
+    mockToolingSupport = {
+      performWebSearch: vi.fn(),
+    };
+
+    mockConfig = {
+      getToolingSupport: vi.fn(() => mockToolingSupport),
       getProxy: () => undefined,
     } as unknown as Config;
-    mockGeminiClient = new GeminiClient(mockConfigInstance);
-    tool = new WebSearchTool(mockConfigInstance);
+
+    tool = new WebSearchTool(mockConfig);
   });
 
   afterEach(() => {
@@ -35,21 +36,21 @@ describe('WebSearchTool', () => {
   });
 
   describe('build', () => {
-    it('should return an invocation for a valid query', () => {
+    it('returns an invocation for a valid query', () => {
       const params: WebSearchToolParams = { query: 'test query' };
       const invocation = tool.build(params);
       expect(invocation).toBeDefined();
       expect(invocation.params).toEqual(params);
     });
 
-    it('should throw an error for an empty query', () => {
+    it('throws for an empty query', () => {
       const params: WebSearchToolParams = { query: '' };
       expect(() => tool.build(params)).toThrow(
         "The 'query' parameter cannot be empty.",
       );
     });
 
-    it('should throw an error for a query with only whitespace', () => {
+    it('throws for a whitespace-only query', () => {
       const params: WebSearchToolParams = { query: '   ' };
       expect(() => tool.build(params)).toThrow(
         "The 'query' parameter cannot be empty.",
@@ -58,67 +59,40 @@ describe('WebSearchTool', () => {
   });
 
   describe('getDescription', () => {
-    it('should return a description of the search', () => {
-      const params: WebSearchToolParams = { query: 'test query' };
+    it('describes the query being executed', () => {
+      const params: WebSearchToolParams = { query: 'describe me' };
       const invocation = tool.build(params);
       expect(invocation.getDescription()).toBe(
-        'Searching the web for: "test query"',
+        'Searching the web for: "describe me"',
       );
     });
   });
 
   describe('execute', () => {
-    it('should return search results for a successful query', async () => {
+    it('delegates to tooling support and returns its result', async () => {
       const params: WebSearchToolParams = { query: 'successful query' };
-      (mockGeminiClient.generateContent as Mock).mockResolvedValue({
-        candidates: [
-          {
-            content: {
-              role: 'model',
-              parts: [{ text: 'Here are your results.' }],
-            },
-          },
-        ],
-      });
+      const adapterResult = {
+        llmContent: 'results',
+        returnDisplay: 'display',
+        sources: [{ web: { uri: 'https://example.com' } }],
+      };
+      mockToolingSupport.performWebSearch.mockResolvedValue(adapterResult);
 
       const invocation = tool.build(params);
       const result = await invocation.execute(abortSignal);
 
-      expect(result.llmContent).toBe(
-        'Web search results for "successful query":\n\nHere are your results.',
+      expect(mockToolingSupport.performWebSearch).toHaveBeenCalledWith(
+        'successful query',
+        abortSignal,
       );
-      expect(result.returnDisplay).toBe(
-        'Search results for "successful query" returned.',
-      );
-      expect(result.sources).toBeUndefined();
+      expect(result).toEqual(adapterResult);
     });
 
-    it('should handle no search results found', async () => {
-      const params: WebSearchToolParams = { query: 'no results query' };
-      (mockGeminiClient.generateContent as Mock).mockResolvedValue({
-        candidates: [
-          {
-            content: {
-              role: 'model',
-              parts: [{ text: '' }],
-            },
-          },
-        ],
-      });
-
-      const invocation = tool.build(params);
-      const result = await invocation.execute(abortSignal);
-
-      expect(result.llmContent).toBe(
-        'No search results or information found for query: "no results query"',
-      );
-      expect(result.returnDisplay).toBe('No information found.');
-    });
-
-    it('should return a WEB_SEARCH_FAILED error on failure', async () => {
+    it('handles errors from tooling support', async () => {
       const params: WebSearchToolParams = { query: 'error query' };
-      const testError = new Error('API Failure');
-      (mockGeminiClient.generateContent as Mock).mockRejectedValue(testError);
+      mockToolingSupport.performWebSearch.mockRejectedValue(
+        new Error('API Failure'),
+      );
 
       const invocation = tool.build(params);
       const result = await invocation.execute(abortSignal);
@@ -127,125 +101,6 @@ describe('WebSearchTool', () => {
       expect(result.llmContent).toContain('Error:');
       expect(result.llmContent).toContain('API Failure');
       expect(result.returnDisplay).toBe('Error performing web search.');
-    });
-
-    it('should correctly format results with sources and citations', async () => {
-      const params: WebSearchToolParams = { query: 'grounding query' };
-      (mockGeminiClient.generateContent as Mock).mockResolvedValue({
-        candidates: [
-          {
-            content: {
-              role: 'model',
-              parts: [{ text: 'This is a test response.' }],
-            },
-            groundingMetadata: {
-              groundingChunks: [
-                { web: { uri: 'https://example.com', title: 'Example Site' } },
-                { web: { uri: 'https://google.com', title: 'Google' } },
-              ],
-              groundingSupports: [
-                {
-                  segment: { startIndex: 5, endIndex: 14 },
-                  groundingChunkIndices: [0],
-                },
-                {
-                  segment: { startIndex: 15, endIndex: 24 },
-                  groundingChunkIndices: [0, 1],
-                },
-              ],
-            },
-          },
-        ],
-      });
-
-      const invocation = tool.build(params);
-      const result = await invocation.execute(abortSignal);
-
-      const expectedLlmContent = `Web search results for "grounding query":
-
-This is a test[1] response.[1][2]
-
-Sources:
-[1] Example Site (https://example.com)
-[2] Google (https://google.com)`;
-
-      expect(result.llmContent).toBe(expectedLlmContent);
-      expect(result.returnDisplay).toBe(
-        'Search results for "grounding query" returned.',
-      );
-      expect(result.sources).toHaveLength(2);
-    });
-
-    it('should insert markers at correct byte positions for multibyte text', async () => {
-      const params: WebSearchToolParams = { query: 'multibyte query' };
-      (mockGeminiClient.generateContent as Mock).mockResolvedValue({
-        candidates: [
-          {
-            content: {
-              role: 'model',
-              parts: [{ text: 'こんにちは! Gemini CLI✨️' }],
-            },
-            groundingMetadata: {
-              groundingChunks: [
-                {
-                  web: {
-                    title: 'Japanese Greeting',
-                    uri: 'https://example.test/japanese-greeting',
-                  },
-                },
-                {
-                  web: {
-                    title: 'google-gemini/gemini-cli',
-                    uri: 'https://github.com/google-gemini/gemini-cli',
-                  },
-                },
-                {
-                  web: {
-                    title: 'Gemini CLI: your open-source AI agent',
-                    uri: 'https://blog.google/technology/developers/introducing-gemini-cli-open-source-ai-agent/',
-                  },
-                },
-              ],
-              groundingSupports: [
-                {
-                  segment: {
-                    // Byte range of "こんにちは!" (utf-8 encoded)
-                    startIndex: 0,
-                    endIndex: 16,
-                  },
-                  groundingChunkIndices: [0],
-                },
-                {
-                  segment: {
-                    // Byte range of "Gemini CLI✨️" (utf-8 encoded)
-                    startIndex: 17,
-                    endIndex: 33,
-                  },
-                  groundingChunkIndices: [1, 2],
-                },
-              ],
-            },
-          },
-        ],
-      });
-
-      const invocation = tool.build(params);
-      const result = await invocation.execute(abortSignal);
-
-      const expectedLlmContent = `Web search results for "multibyte query":
-
-こんにちは![1] Gemini CLI✨️[2][3]
-
-Sources:
-[1] Japanese Greeting (https://example.test/japanese-greeting)
-[2] google-gemini/gemini-cli (https://github.com/google-gemini/gemini-cli)
-[3] Gemini CLI: your open-source AI agent (https://blog.google/technology/developers/introducing-gemini-cli-open-source-ai-agent/)`;
-
-      expect(result.llmContent).toBe(expectedLlmContent);
-      expect(result.returnDisplay).toBe(
-        'Search results for "multibyte query" returned.',
-      );
-      expect(result.sources).toHaveLength(3);
     });
   });
 });

--- a/packages/core/src/tools/web-search.ts
+++ b/packages/core/src/tools/web-search.ts
@@ -4,37 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { GroundingMetadata } from '@google/genai';
 import type { ToolInvocation, ToolResult } from './tools.js';
 import { BaseDeclarativeTool, BaseToolInvocation, Kind } from './tools.js';
 import { ToolErrorType } from './tool-error.js';
 
 import { getErrorMessage } from '../utils/errors.js';
 import { type Config } from '../config/config.js';
-import { getResponseText } from '../utils/partUtils.js';
-import { DEFAULT_GEMINI_FLASH_MODEL } from '../config/models.js';
-
-interface GroundingChunkWeb {
-  uri?: string;
-  title?: string;
-}
-
-interface GroundingChunkItem {
-  web?: GroundingChunkWeb;
-  // Other properties might exist if needed in the future
-}
-
-interface GroundingSupportSegment {
-  startIndex: number;
-  endIndex: number;
-  text?: string; // text is optional as per the example
-}
-
-interface GroundingSupportItem {
-  segment?: GroundingSupportSegment;
-  groundingChunkIndices?: number[];
-  confidenceScores?: number[]; // Optional as per example
-}
 
 /**
  * Parameters for the WebSearchTool.
@@ -51,9 +26,7 @@ export interface WebSearchToolParams {
  * Extends ToolResult to include sources for web search.
  */
 export interface WebSearchToolResult extends ToolResult {
-  sources?: GroundingMetadata extends { groundingChunks: GroundingChunkItem[] }
-    ? GroundingMetadata['groundingChunks']
-    : GroundingChunkItem[];
+  sources?: unknown;
 }
 
 class WebSearchToolInvocation extends BaseToolInvocation<
@@ -72,94 +45,10 @@ class WebSearchToolInvocation extends BaseToolInvocation<
   }
 
   async execute(signal: AbortSignal): Promise<WebSearchToolResult> {
-    const geminiClient = this.config.getGeminiClient();
+    const toolingSupport = this.config.getToolingSupport();
 
     try {
-      const response = await geminiClient.generateContent(
-        [{ role: 'user', parts: [{ text: this.params.query }] }],
-        { tools: [{ googleSearch: {} }] },
-        signal,
-        DEFAULT_GEMINI_FLASH_MODEL,
-      );
-
-      const responseText = getResponseText(response);
-      const groundingMetadata = response.candidates?.[0]?.groundingMetadata;
-      const sources = groundingMetadata?.groundingChunks as
-        | GroundingChunkItem[]
-        | undefined;
-      const groundingSupports = groundingMetadata?.groundingSupports as
-        | GroundingSupportItem[]
-        | undefined;
-
-      if (!responseText || !responseText.trim()) {
-        return {
-          llmContent: `No search results or information found for query: "${this.params.query}"`,
-          returnDisplay: 'No information found.',
-        };
-      }
-
-      let modifiedResponseText = responseText;
-      const sourceListFormatted: string[] = [];
-
-      if (sources && sources.length > 0) {
-        sources.forEach((source: GroundingChunkItem, index: number) => {
-          const title = source.web?.title || 'Untitled';
-          const uri = source.web?.uri || 'No URI';
-          sourceListFormatted.push(`[${index + 1}] ${title} (${uri})`);
-        });
-
-        if (groundingSupports && groundingSupports.length > 0) {
-          const insertions: Array<{ index: number; marker: string }> = [];
-          groundingSupports.forEach((support: GroundingSupportItem) => {
-            if (support.segment && support.groundingChunkIndices) {
-              const citationMarker = support.groundingChunkIndices
-                .map((chunkIndex: number) => `[${chunkIndex + 1}]`)
-                .join('');
-              insertions.push({
-                index: support.segment.endIndex,
-                marker: citationMarker,
-              });
-            }
-          });
-
-          // Sort insertions by index in descending order to avoid shifting subsequent indices
-          insertions.sort((a, b) => b.index - a.index);
-
-          // Use TextEncoder/TextDecoder since segment indices are UTF-8 byte positions
-          const encoder = new TextEncoder();
-          const responseBytes = encoder.encode(modifiedResponseText);
-          const parts: Uint8Array[] = [];
-          let lastIndex = responseBytes.length;
-          for (const ins of insertions) {
-            const pos = Math.min(ins.index, lastIndex);
-            parts.unshift(responseBytes.subarray(pos, lastIndex));
-            parts.unshift(encoder.encode(ins.marker));
-            lastIndex = pos;
-          }
-          parts.unshift(responseBytes.subarray(0, lastIndex));
-
-          // Concatenate all parts into a single buffer
-          const totalLength = parts.reduce((sum, part) => sum + part.length, 0);
-          const finalBytes = new Uint8Array(totalLength);
-          let offset = 0;
-          for (const part of parts) {
-            finalBytes.set(part, offset);
-            offset += part.length;
-          }
-          modifiedResponseText = new TextDecoder().decode(finalBytes);
-        }
-
-        if (sourceListFormatted.length > 0) {
-          modifiedResponseText +=
-            '\n\nSources:\n' + sourceListFormatted.join('\n');
-        }
-      }
-
-      return {
-        llmContent: `Web search results for "${this.params.query}":\n\n${modifiedResponseText}`,
-        returnDisplay: `Search results for "${this.params.query}" returned.`,
-        sources,
-      };
+      return await toolingSupport.performWebSearch(this.params.query, signal);
     } catch (error: unknown) {
       const errorMessage = `Error during web search for query "${
         this.params.query

--- a/packages/core/src/utils/getFolderStructure.test.ts
+++ b/packages/core/src/utils/getFolderStructure.test.ts
@@ -255,8 +255,8 @@ ${testRootDir}${path.sep}
       await createTestFile('file1.txt');
       await createTestFile('node_modules', 'some-package', 'index.js');
       await createTestFile('ignored.txt');
-      await createTestFile('.gemini', 'config.yaml');
-      await createTestFile('.gemini', 'logs.json');
+      await createTestFile('.ionesco', 'config.yaml');
+      await createTestFile('.ionesco', 'logs.json');
 
       const fileService = new FileDiscoveryService(testRootDir);
       const structure = await getFolderStructure(testRootDir, {
@@ -301,8 +301,8 @@ ${testRootDir}${path.sep}
       await createTestFile('file1.txt');
       await createTestFile('node_modules', 'some-package', 'index.js');
       await createTestFile('ignored.txt');
-      await createTestFile('.gemini', 'config.yaml');
-      await createTestFile('.gemini', 'logs.json');
+      await createTestFile('.ionesco', 'config.yaml');
+      await createTestFile('.ionesco', 'logs.json');
 
       const fileService = new FileDiscoveryService(testRootDir);
       const structure = await getFolderStructure(testRootDir, {
@@ -321,8 +321,8 @@ ${testRootDir}${path.sep}
       await createTestFile('file1.txt');
       await createTestFile('node_modules', 'some-package', 'index.js');
       await createTestFile('ignored.txt');
-      await createTestFile('.gemini', 'config.yaml');
-      await createTestFile('.gemini', 'logs.json');
+      await createTestFile('.ionesco', 'config.yaml');
+      await createTestFile('.ionesco', 'logs.json');
 
       const fileService = new FileDiscoveryService(testRootDir);
       const structure = await getFolderStructure(testRootDir, {

--- a/packages/core/src/utils/installationManager.test.ts
+++ b/packages/core/src/utils/installationManager.test.ts
@@ -41,7 +41,7 @@ describe('InstallationManager', () => {
   let tempHomeDir: string;
   let installationManager: InstallationManager;
   const installationIdFile = () =>
-    path.join(tempHomeDir, '.gemini', 'installation_id');
+    path.join(tempHomeDir, '.ionesco', 'installation_id');
 
   beforeEach(() => {
     tempHomeDir = fs.mkdtempSync(

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -8,7 +8,7 @@ import path from 'node:path';
 import os from 'node:os';
 import * as crypto from 'node:crypto';
 
-export const GEMINI_DIR = '.gemini';
+export const GEMINI_DIR = '.ionesco';
 export const GOOGLE_ACCOUNTS_FILENAME = 'google_accounts.json';
 
 /**

--- a/packages/core/src/utils/userAccountManager.test.ts
+++ b/packages/core/src/utils/userAccountManager.test.ts
@@ -30,7 +30,7 @@ describe('UserAccountManager', () => {
     );
     (os.homedir as Mock).mockReturnValue(tempHomeDir);
     accountsFile = () =>
-      path.join(tempHomeDir, '.gemini', 'google_accounts.json');
+      path.join(tempHomeDir, '.ionesco', 'google_accounts.json');
     userAccountManager = new UserAccountManager();
   });
 

--- a/providers/grok_sidecar/runner.py
+++ b/providers/grok_sidecar/runner.py
@@ -66,8 +66,9 @@ class SidecarRunner:
                 self._send_error(request_id, "Missing requestId or action")
                 continue
 
+            handler_name = f"_handle_{action.replace('.', '_')}"
             try:
-                handler = getattr(self, f"_handle_{action}")
+                handler = getattr(self, handler_name)
             except AttributeError:
                 self._send_error(request_id, f"Unknown action: {action}")
                 continue
@@ -197,6 +198,38 @@ class SidecarRunner:
 
         acknowledgement = {"callId": call_id, "acknowledged": True}
         self._send_result(request_id, acknowledgement)
+
+    def _handle_tooling_webSearch(self, request_id: str, payload: dict) -> None:
+        query = payload.get("query", "")
+        options = payload.get("options") or {}
+        result = self._service.web_search(query=query, **options)
+        self._send_result(request_id, result)
+
+    def _handle_tooling_webFetch(self, request_id: str, payload: dict) -> None:
+        prompt = payload.get("prompt", "")
+        options = payload.get("options") or {}
+        result = self._service.web_fetch(prompt=prompt, **options)
+        self._send_result(request_id, result)
+
+    def _handle_tooling_ensureCorrectEdit(self, request_id: str, payload: dict) -> None:
+        result = self._service.ensure_correct_edit(**payload)
+        self._send_result(request_id, result)
+
+    def _handle_tooling_ensureCorrectFileContent(
+        self, request_id: str, payload: dict
+    ) -> None:
+        result = self._service.ensure_correct_file_content(**payload)
+        self._send_result(request_id, result)
+
+    def _handle_tooling_fixEditWithInstruction(
+        self, request_id: str, payload: dict
+    ) -> None:
+        result = self._service.fix_edit_with_instruction(**payload)
+        self._send_result(request_id, result)
+
+    def _handle_tooling_summarizeText(self, request_id: str, payload: dict) -> None:
+        result = self._service.summarize_text(**payload)
+        self._send_result(request_id, result)
 
     def _handle_upload(self, request_id: str, payload: dict) -> None:
         result = self._service.upload(

--- a/scripts/sandbox_command.js
+++ b/scripts/sandbox_command.js
@@ -35,7 +35,7 @@ const argv = yargs(hideBin(process.argv)).option('q', {
 let geminiSandbox = process.env.GEMINI_SANDBOX;
 
 if (!geminiSandbox) {
-  const userSettingsFile = join(os.homedir(), '.gemini', 'settings.json');
+  const userSettingsFile = join(os.homedir(), '.ionesco', 'settings.json');
   if (existsSync(userSettingsFile)) {
     const settings = JSON.parse(
       stripJsonComments(readFileSync(userSettingsFile, 'utf-8')),
@@ -49,7 +49,7 @@ if (!geminiSandbox) {
 if (!geminiSandbox) {
   let currentDir = process.cwd();
   while (true) {
-    const geminiEnv = join(currentDir, '.gemini', '.env');
+    const geminiEnv = join(currentDir, '.ionesco', '.env');
     const regularEnv = join(currentDir, '.env');
     if (existsSync(geminiEnv)) {
       dotenv.config({ path: geminiEnv, quiet: true });

--- a/scripts/start.bat
+++ b/scripts/start.bat
@@ -26,10 +26,8 @@ if "%GROK_PYTHON_BIN%"=="" (
 call :load_env "%REPO_ROOT%\.env"
 call :load_env "%SIDECAR_DIR%\.env"
 
-pushd "%REPO_ROOT%"
-  echo [start] Starting CLI (npm run start)
-  npm run start
-popd
+echo [start] Starting CLI via scripts\start.js
+node "%REPO_ROOT%\scripts\start.js"
 exit /b %errorlevel%
 
 :load_env

--- a/scripts/telemetry.js
+++ b/scripts/telemetry.js
@@ -12,7 +12,7 @@ import { existsSync, readFileSync } from 'node:fs';
 
 const projectRoot = join(import.meta.dirname, '..');
 
-const SETTINGS_DIRECTORY_NAME = '.gemini';
+const SETTINGS_DIRECTORY_NAME = '.ionesco';
 const USER_SETTINGS_DIR = join(
   process.env.HOME || process.env.USERPROFILE || process.env.HOMEPATH || '',
   SETTINGS_DIRECTORY_NAME,

--- a/scripts/telemetry_utils.js
+++ b/scripts/telemetry_utils.js
@@ -24,9 +24,9 @@ const projectHash = crypto
   .digest('hex');
 
 // User-level .gemini directory in home
-const USER_GEMINI_DIR = path.join(os.homedir(), '.gemini');
+const USER_GEMINI_DIR = path.join(os.homedir(), '.ionesco');
 // Project-level .gemini directory in the workspace
-const WORKSPACE_GEMINI_DIR = path.join(projectRoot, '.gemini');
+const WORKSPACE_GEMINI_DIR = path.join(projectRoot, '.ionesco');
 
 // Telemetry artifacts are stored in a hashed directory under the user's ~/.gemini/tmp
 export const OTEL_DIR = path.join(USER_GEMINI_DIR, 'tmp', projectHash, 'otel');

--- a/set-ionesco-alias.sh
+++ b/set-ionesco-alias.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_SOURCE="${BASH_SOURCE[0]}"
+SCRIPT_DIR="$(cd -- "$(dirname "${SCRIPT_SOURCE}")" && pwd)"
+REPO_ROOT="${SCRIPT_DIR}"
+START_BIN="${REPO_ROOT}/start.sh"
+
+if [[ ! -x "${START_BIN}" ]]; then
+  printf 'Error: start script not found at %s\n' "${START_BIN}" >&2
+  exit 1
+fi
+
+CURRENT_SHELL="${SHELL:-}"
+if [[ -z "${CURRENT_SHELL}" ]]; then
+  printf 'Error: SHELL is not set. Run this from within your shell so it can detect where to write the alias.\n' >&2
+  exit 1
+fi
+
+SHELL_NAME="$(basename "${CURRENT_SHELL}")"
+case "${SHELL_NAME}" in
+  bash|zsh)
+    RC_FILE="${HOME}/.${SHELL_NAME}rc"
+    if [[ ! -f "${RC_FILE}" ]]; then
+      printf 'Creating %s\n' "${RC_FILE}"
+      touch "${RC_FILE}"
+    fi
+    if grep -q "alias ionesco=" "${RC_FILE}"; then
+      printf 'An ionesco alias already exists in %s\n' "${RC_FILE}"
+      exit 0
+    fi
+    printf "alias ionesco='%s'\n" "${START_BIN}" >> "${RC_FILE}"
+    printf 'Alias added to %s. Reload your shell with: source %s\n' "${RC_FILE}" "${RC_FILE}"
+    ;;
+  fish)
+    CONFIG="${HOME}/.config/fish/config.fish"
+    if [[ ! -f "${CONFIG}" ]]; then
+      printf 'Creating %s\n' "${CONFIG}"
+      mkdir -p "$(dirname "${CONFIG}")"
+      touch "${CONFIG}"
+    fi
+    if grep -q "alias ionesco" "${CONFIG}"; then
+      printf 'An ionesco alias already exists in %s\n' "${CONFIG}"
+      exit 0
+    fi
+    printf "alias ionesco '%s'\n" "${START_BIN}" >> "${CONFIG}"
+    printf 'Alias added to %s. Run: source %s\n' "${CONFIG}" "${CONFIG}"
+    ;;
+  *)
+    printf 'Unsupported shell (%s). Add this line to your shell init file manually:\n  alias ionesco=\"%s\"\n' "${CURRENT_SHELL}" "${START_BIN}"
+    ;;
+esac

--- a/setup.sh
+++ b/setup.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 SCRIPT_SOURCE="${BASH_SOURCE[0]}"
 SCRIPT_DIR="$(cd -- "$(dirname "$SCRIPT_SOURCE")" && pwd)"
-REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="${SCRIPT_DIR}"
 SIDECAR_DIR="${REPO_ROOT}/providers/grok_sidecar"
 VENV_DIR="${SIDECAR_DIR}/.venv"
 REQ_FILE="${SIDECAR_DIR}/requirements.txt"
@@ -111,7 +111,7 @@ log "and run the CLI via npm scripts as needed."
 # ---------------------------------------------------------------------------
 # Offer global ionesco alias for convenience
 # ---------------------------------------------------------------------------
-PROJECT_BIN="${REPO_ROOT}/scripts/start.sh"
+PROJECT_BIN="${REPO_ROOT}/start.sh"
 if [[ -n "${SHELL:-}" ]] && [[ "${SHELL}" == *"/bash" || "${SHELL}" == *"/zsh" ]]; then
   SHELL_RC="${HOME}/.$(basename "${SHELL}")rc"
   if [[ -f "${SHELL_RC}" ]]; then
@@ -124,5 +124,5 @@ if [[ -n "${SHELL:-}" ]] && [[ "${SHELL}" == *"/bash" || "${SHELL}" == *"/zsh" ]
     fi
   fi
 else
-  log "Skipped alias setup (unsupported shell). Run ./scripts/create_alias.sh manually if desired."
+  log "Skipped alias setup (unsupported shell). Run ./set-ionesco-alias.sh manually if desired."
 fi

--- a/start.sh
+++ b/start.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 SCRIPT_SOURCE="${BASH_SOURCE[0]}"
 SCRIPT_DIR="$(cd -- "$(dirname "$SCRIPT_SOURCE")" && pwd)"
-REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="${SCRIPT_DIR}"
 SIDECAR_DIR="${REPO_ROOT}/providers/grok_sidecar"
 VENV_DIR="${SIDECAR_DIR}/.venv"
 
@@ -20,16 +20,16 @@ fail() {
 
 # Ensure setup artifacts exist
 if [[ ! -d "${REPO_ROOT}/node_modules" ]]; then
-  fail "node_modules not found. Run ./scripts/setup.sh first."
+  fail "node_modules not found. Run ./setup.sh first."
 fi
 
 if [[ ! -d "${VENV_DIR}" ]]; then
-  fail "Grok sidecar virtualenv missing. Run ./scripts/setup.sh first."
+  fail "Grok sidecar virtualenv missing. Run ./setup.sh first."
 fi
 
 VENV_PY="${VENV_DIR}/bin/python"
 if [[ ! -x "${VENV_PY}" ]]; then
-  fail "${VENV_PY} not found or not executable. Re-run ./scripts/setup.sh."
+  fail "${VENV_PY} not found or not executable. Re-run ./setup.sh."
 fi
 
 # Export Grok-specific environment variables if available
@@ -60,5 +60,6 @@ load_env_file() {
 load_env_file "${REPO_ROOT}/.env"
 load_env_file "${SIDECAR_DIR}/.env"
 
-log "Starting CLI (npm run start)"
-(cd "${REPO_ROOT}" && npm run start)
+log "Starting CLI via scripts/start.js"
+
+node "${REPO_ROOT}/scripts/start.js"


### PR DESCRIPTION
## TLDR
Ionesco scripts moved to main directory, now keeps the cwd when you call "ionesco" from any arbitrary directory, just gemini-cli
<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper
Ported tools like search and smartedit to work native with the grok provider.
<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
